### PR TITLE
Unify branch creation into switch command with git-like behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,12 @@ Thumbs.db
 
 # claude directory
 .claude/
+
+# Thoughts data directory (created by thoughts init)
+/.thoughts-data
+
+# Claude settings backup (managed by thoughts)
+/.claude/settings.local.json.bak
+
+# Claude settings quarantine backups (auto-pruned)
+/.claude/settings.local.json.malformed.*.bak

--- a/.thoughts/config.json
+++ b/.thoughts/config.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0",
+  "mount_dirs": {
+    "thoughts": "thoughts",
+    "context": "context",
+    "references": "references"
+  },
+  "thoughts_mount": {
+    "remote": "git@github.com:General-Wisdom/thoughts.git",
+    "subpath": "repos/gwt/thoughts",
+    "sync": "auto"
+  },
+  "context_mounts": [
+    {
+      "remote": "git@github.com:General-Wisdom/thoughts.git",
+      "subpath": "repos/gwt/general",
+      "mount_path": "general",
+      "sync": "auto"
+    },
+    {
+      "remote": "git@github.com:General-Wisdom/thoughts.git",
+      "subpath": "linear_tickets",
+      "mount_path": "tickets",
+      "sync": "auto"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,22 +2,31 @@
 
 (this is very new untested code -- please report bugs)
 
-An opinionated tool for rapidly working in git worktrees.  `gwt` makes
-it fast and easy to:
+An opinionated tool for rapidly working in git worktrees. `gwt` works like `git switch` but automatically manages worktrees. It makes it fast and easy to:
 
 - See all existing branch+worktrees in the current repo
 
   `gwt` or `gwt list` or `gwt ls`
 
-- Change directory to a branch+worktree [in the current repo]
+- Switch to a branch+worktree [in the current repo]
 
   `gwt switch branch-name` or `gwt s branch-name` 
   
-  (supports tab completion of existing branch+worktrees)
+  This command:
+  - Switches to existing worktree if it exists
+  - Creates worktree for existing local branch
+  - Auto-tracks remote branches (with --guess, enabled by default)
+  - Shows helpful error if branch doesn't exist
+  
+  (supports tab completion of ALL branches: worktrees, local, and remote)
 
 - Create a new branch+worktree [in the current repo]
 
-  `gwt --new branch-name`
+  `gwt switch -c branch-name` or `gwt s -c branch-name`
+  
+  Additional options:
+  - `-C` or `--force-create`: Create branch, resetting if it exists
+  - `--no-guess`: Disable remote branch auto-detection
 
 - Remove a worktree and optionally its branch
 
@@ -168,15 +177,28 @@ gwt list
 gwt ls
 ```
 
-Create a new branch and worktree:
-```
-gwt --new branch-name
-```
-
-Switch to an existing worktree:
+Switch to a branch (creates worktree if needed):
 ```
 gwt switch branch-name
 gwt s branch-name
+```
+
+Create a new branch and worktree:
+```
+gwt switch -c branch-name
+gwt s -c branch-name
+```
+
+Force create/reset a branch:
+```
+gwt switch -C branch-name
+```
+
+Switch to a remote branch (auto-tracks by default):
+```
+gwt switch remote-branch-name
+# Or explicitly disable remote detection:
+gwt switch --no-guess branch-name
 ```
 
 Set the git directory for future commands:

--- a/context
+++ b/context
@@ -1,0 +1,1 @@
+.thoughts-data/context

--- a/gwt.fish
+++ b/gwt.fish
@@ -59,7 +59,9 @@ end
 function __gwt_complete_branches
     set -l SCRIPT_DIR (dirname (status -f))
     set -l PYTHON_SCRIPT "$SCRIPT_DIR/gwt.py"
-    $PYTHON_SCRIPT list --branches 2>/dev/null
+    # Try all branches first, fallback to worktrees
+    $PYTHON_SCRIPT list --branches all 2>/dev/null
+    or $PYTHON_SCRIPT list --branches worktrees 2>/dev/null
 end
 
 function __gwt_complete
@@ -67,7 +69,7 @@ function __gwt_complete
     set -l cur (commandline -ct)
     
     # Commands
-    set -l commands new track repo switch s list ls l remove rm
+    set -l commands repo switch s list ls l remove rm
     
     # Complete first argument with commands
     if test (count $cmd) -eq 1
@@ -87,4 +89,4 @@ function __gwt_complete
     end
 end
 
-complete -c gwt -f -a '(__gwt_complete)'
+complete -c gwt -f -k -a '(__gwt_complete)'

--- a/gwt.sh
+++ b/gwt.sh
@@ -19,15 +19,17 @@ if [ ! -x "$PYTHON_SCRIPT" ]; then
 fi
 
 _gwt_get_branches() {
-    # Function to get list of branch names with worktrees
-    output=$("$PYTHON_SCRIPT" list --branches 2>&1)
+    # Function to get list of branch names
+    # Default to "all" branches for comprehensive completion
+    output=$("$PYTHON_SCRIPT" list --branches all 2>&1)
     result=$?
     
     if [ $result -eq 0 ]; then
         echo "$output"
     else
-        # Return empty to indicate failure
-        echo ""
+        # Fallback to worktrees only if all branches fails
+        output=$("$PYTHON_SCRIPT" list --branches worktrees 2>&1)
+        echo "$output"
     fi
 }
 
@@ -36,7 +38,7 @@ _gwt_completions() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    commands="new track repo switch s list ls l remove rm"
+    commands="repo switch s list ls l remove rm"
     
     # Don't use file completion as a fallback
     compopt -o nospace
@@ -52,10 +54,6 @@ _gwt_completions() {
     # For position 2, handle specific subcommand completions
     if [[ ${COMP_CWORD} -eq 2 ]]; then
         case "${prev}" in
-            new|track)
-                # No specific completions for new or track since they expect a branch name
-                return 0
-                ;;
             repo)
                 # Use directory completion for repo command
                 compopt -o filenames -o nospace

--- a/references
+++ b/references
@@ -1,0 +1,1 @@
+.thoughts-data/references

--- a/thoughts
+++ b/thoughts
@@ -1,0 +1,1 @@
+.thoughts-data/thoughts


### PR DESCRIPTION
## What problem(s) was I solving?

The original `gwt` command had a fragmented UX with three separate commands for branch operations:
- `gwt new branch-name` - create new branch with worktree
- `gwt track branch-name` - track remote branch with worktree  
- `gwt switch branch-name` - switch to existing worktree (failed if worktree didn't exist)

This created confusion and friction:
1. Users had to remember which command to use based on whether a branch existed locally, remotely, or not at all
2. The `switch` command would fail if a worktree didn't exist for an existing branch, requiring manual worktree creation
3. No automatic remote branch detection - users had to explicitly use `track` for remote branches
4. Tab completion only showed existing worktrees, not all available branches

## What user-facing changes did I ship?

Unified all branch operations into a single `gwt switch` command with git-like behavior:

**New `switch` command flags:**
- `gwt switch branch-name` - intelligently handles all scenarios (existing worktree, local branch, remote branch)
- `gwt switch -c branch-name` - create new branch (fails if exists)
- `gwt switch -C branch-name` - force create/reset branch
- `gwt switch --no-guess branch-name` - disable automatic remote branch detection

**Automatic behaviors:**
- Auto-creates worktrees for existing local branches (no more "branch exists but no worktree" errors)
- Auto-tracks remote branches by default when they match the requested name
- Fetches remotes automatically to find matching branches

**Enhanced tab completion:**
- Now shows ALL available branches: existing worktrees, local branches, and remote branches
- Prioritizes completion results: worktrees first, then local branches, then remote branches

**Removed commands:**
- `gwt new` - replaced by `gwt switch -c`
- `gwt track` - replaced by automatic remote detection in `gwt switch`

## How I implemented it

**Core refactoring (gwt.py):**
- Created `switch_branch()` function that unifies all branch/worktree creation logic
- Implemented `find_remote_branch()` to search for matching remote branches across all remotes (prefers origin)
- Added `branch_exists_locally()` helper for checking local branch existence
- Separated worktree creation into distinct functions:
  - `create_worktree_for_branch()` - for existing local branches
  - `create_tracking_worktree()` - for remote branches
  - `run_post_create_commands()` - extracted common post-creation logic
- Enhanced `get_worktree_list()` and `get_git_worktrees()` to optionally include main worktree

**Branch listing improvements:**
- Replaced `list_worktrees(..., branches_only=True)` with `list_all_branches()` function
- Added support for different listing modes: "all", "local", "worktrees"
- Properly categorizes and orders branches for completion

**Shell integration updates:**
- Updated bash completion (gwt.sh) to use new `--branches all` flag
- Updated fish completion (gwt.fish) to show all branches with fallback
- Both shells now complete from all available branches, not just existing worktrees

**Documentation:**
- Updated README with new switch command syntax and examples
- Added `.thoughts` configuration for Claude Code integration
- Enhanced .gitignore for thoughts-related artifacts

## How to verify it

- [x] I have ensured `make check test` passes (verified via CI checks: flake8 linting and shellcheck)

**Manual testing scenarios:**
- [x] Test `gwt switch -c new-branch` creates new branch and worktree
- [x] Test `gwt switch existing-local-branch` creates worktree for existing branch
- [x] Test `gwt switch remote-branch` auto-tracks and creates worktree for remote branch
- [x] Test `gwt switch -C existing-branch` force resets branch
- [x] Test `gwt switch --no-guess branch-name` disables remote detection
- [x] Verify tab completion shows worktrees, local branches, and remote branches
- [x] Verify helpful error messages when branch doesn't exist

## Description for the changelog

Unified branch operations into `gwt switch` command with git-like behavior. The `switch` command now auto-creates worktrees for existing branches, auto-tracks remote branches, and supports `-c`/`-C` flags for branch creation. Removed separate `new` and `track` commands. Enhanced tab completion to show all available branches (worktrees, local, and remote).
