### PR TITLE
Atomicize `rm`; add `gc` for garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ An opinionated tool for rapidly working in git worktrees. `gwt` works like `git 
   - `-C` or `--force-create`: Create branch, resetting if it exists
   - `--no-guess`: Disable remote branch auto-detection
 
-- Remove a worktree and optionally its branch
+- Remove a worktree and clean up branches
 
   `gwt remove branch-name` or `gwt rm branch-name`
+  
+  The behavior depends on the branch state:
+  - **PR merged**: Automatically removes worktree, local branch, and remote branch
+  - **Local only** (not pushed): Removes worktree, prompts for local branch deletion
+  - **Pushed but PR not merged**: Shows warning, prompts for each deletion
+  
+  This requires the `gh` CLI for PR status detection.
 
 - Switch to a different repo
 
@@ -225,11 +232,16 @@ Set the git directory for future commands:
 gwt --repo /path/to/another/repo.git
 ```
 
-Remove a worktree and optionally its branch:
+Remove a worktree and clean up branches:
 ```
 gwt remove branch-name
 gwt rm branch-name
 ```
+
+The removal behavior is context-aware:
+- If the PR has been merged, `gwt rm` automatically cleans up the worktree, local branch, and remote branch
+- If the branch was never pushed to a remote, it removes the worktree and prompts about the local branch
+- If the branch is pushed but the PR isn't merged, it warns you and prompts for confirmation before each deletion
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An opinionated tool for rapidly working in git worktrees. `gwt` works like `git 
   
   This command:
   - Switches to existing worktree if it exists
-  - Creates worktree for existing local branch
+  - Creates worktree for existing local branch (and runs post-create commands)
   - Auto-tracks remote branches (with --guess, enabled by default)
   - Shows helpful error if branch doesn't exist
   
@@ -182,7 +182,7 @@ post_create_commands = [
 #### Configuration Options
 
 - `default_repo`: Path to the git directory to use by default when `GWT_GIT_DIR` is not set
-- `repos.<git-dir>.post_create_commands`: List of shell commands to run after creating a new worktree. These commands run in the newly created worktree directory.
+- `repos.<git-dir>.post_create_commands`: List of shell commands to run after creating a new worktree. These commands run in the newly created worktree directory. Post-create commands run whenever `gwt switch` creates a worktree (for local branches, remote branches, or new branches with `-c`).
 
 The configuration file is created automatically when you first use the `gwt --repo` command. You can then edit it manually to add post-create commands or other settings.
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ gwt --repo /path/to/another/repo.git
 ```
 
 Remove a worktree and clean up branches:
-```
+
+```bash
 gwt remove branch-name
 gwt rm branch-name
 ```

--- a/gwt.fish
+++ b/gwt.fish
@@ -80,7 +80,7 @@ end
 function __gwt_complete
     set -l cmd (commandline -opc)
     set -l cur (commandline -ct)
-    set -l commands repo switch s list ls l remove rm
+    set -l commands repo switch s list ls l remove rm gc
 
     if test (count $cmd) -eq 1
         printf '%s\n' $commands

--- a/gwt.py
+++ b/gwt.py
@@ -4,6 +4,7 @@
 # dependencies = [
 #   "tomli>=2.0.0; python_version < '3.11'",
 #   "tomli-w>=1.0.0",
+#   "tqdm>=4.0.0",
 # ]
 # ///
 

--- a/gwt.py
+++ b/gwt.py
@@ -16,12 +16,14 @@ from gwtlib.api import (
     branch_exists_locally,
     create_worktree_for_branch,
     get_main_worktree_path,
+    get_remote_tracking_branch,
     get_worktree_base,
     get_worktree_list,
     is_path_current_worktree,
     parse_worktree_legacy,
     parse_worktree_porcelain,
     rel_display_path,
+    remote_branch_exists,
 )
 from gwtlib.cli import main  # CLI entrypoint
 
@@ -34,6 +36,8 @@ __all__ = [
     "rel_display_path",
     "create_worktree_for_branch",
     "branch_exists_locally",
+    "get_remote_tracking_branch",
+    "remote_branch_exists",
     "parse_worktree_porcelain",
     "parse_worktree_legacy",
     "get_worktree_list",

--- a/gwt.sh
+++ b/gwt.sh
@@ -54,7 +54,7 @@ _gwt_completions() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    commands="repo switch s list ls l remove rm"
+    commands="repo switch s list ls l remove rm gc"
 
     # Don't use file completion as a fallback
     compopt -o nospace

--- a/gwtlib/api.py
+++ b/gwtlib/api.py
@@ -6,6 +6,7 @@ from gwtlib.branches import (
 )
 from gwtlib.display import ColorMode
 from gwtlib.parsing import (
+    get_main_branch_name,
     get_worktree_list,
     parse_worktree_legacy,
     parse_worktree_porcelain,
@@ -35,6 +36,7 @@ __all__ = [
     "parse_worktree_porcelain",
     "parse_worktree_legacy",
     "get_worktree_list",
+    "get_main_branch_name",
     # resolution
     "auto_detect_git_dir",
     # display

--- a/gwtlib/api.py
+++ b/gwtlib/api.py
@@ -1,5 +1,9 @@
 # gwtlib/api.py
-from gwtlib.branches import branch_exists_locally
+from gwtlib.branches import (
+    branch_exists_locally,
+    get_remote_tracking_branch,
+    remote_branch_exists,
+)
 from gwtlib.display import ColorMode
 from gwtlib.parsing import (
     get_worktree_list,
@@ -25,6 +29,8 @@ __all__ = [
     "create_worktree_for_branch",
     # branches
     "branch_exists_locally",
+    "get_remote_tracking_branch",
+    "remote_branch_exists",
     # parsing
     "parse_worktree_porcelain",
     "parse_worktree_legacy",

--- a/gwtlib/branches.py
+++ b/gwtlib/branches.py
@@ -5,20 +5,6 @@ from typing import Optional, Tuple
 from gwtlib.git_ops import run_git_command, run_git_quiet
 
 
-def get_main_branch_name(git_dir):
-    """Extract the main branch name from git worktree list."""
-    try:
-        result = run_git_command(["worktree", "list"], git_dir)
-        lines = result.stdout.splitlines()
-        if lines:
-            parts = lines[0].split()
-            if len(parts) >= 3:
-                return parts[2].strip("[]")
-    except Exception:
-        pass
-    return None
-
-
 def branch_exists_locally(branch_name, git_dir):
     """Check if a branch exists locally via git rev-parse."""
     try:
@@ -136,34 +122,3 @@ def delete_remote_branch(
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.strip() if e.stderr else str(e)
         return (False, error_msg)
-
-
-def get_pr_state(branch_name: str) -> Optional[Tuple[str, bool]]:
-    """Check the PR state for a branch using GitHub CLI.
-
-    Returns:
-        Tuple of (state, is_merged) where state is 'OPEN', 'CLOSED', or 'MERGED',
-        or None if no PR exists or gh CLI is not available.
-
-    Note: This uses the gh CLI and works in any directory with a GitHub remote.
-    """
-    try:
-        # Use gh pr view to get PR info for this branch
-        result = subprocess.run(
-            ["gh", "pr", "view", branch_name, "--json", "state,mergedAt"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            return None
-
-        import json
-
-        data = json.loads(result.stdout)
-        state = data.get("state", "UNKNOWN")
-        merged_at = data.get("mergedAt")
-        is_merged = merged_at is not None
-
-        return (state, is_merged)
-    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError):
-        return None

--- a/gwtlib/branches.py
+++ b/gwtlib/branches.py
@@ -103,6 +103,7 @@ def can_delete_remote_branch(
 
     Returns:
         Tuple of (can_delete, error_message). If can_delete is True, error_message is empty.
+        Returns (True, "") if branch is already deleted (goal achieved).
     """
     try:
         # Use --dry-run to check without actually deleting
@@ -110,6 +111,9 @@ def can_delete_remote_branch(
         return (True, "")
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.strip() if e.stderr else str(e)
+        # "remote ref does not exist" means branch is already gone - that's fine
+        if "remote ref does not exist" in error_msg.lower():
+            return (True, "")
         return (False, error_msg)
 
 

--- a/gwtlib/branches.py
+++ b/gwtlib/branches.py
@@ -1,4 +1,7 @@
 # gwtlib/branches.py
+import subprocess
+from typing import Optional, Tuple
+
 from gwtlib.git_ops import run_git_command, run_git_quiet
 
 
@@ -41,3 +44,97 @@ def find_remote_branch(branch_name, git_dir):
                 return ref
         return refs[0]
     return None
+
+
+def get_remote_tracking_branch(branch_name: str, git_dir: str) -> Optional[str]:
+    """Get the remote tracking branch for a local branch, if any.
+
+    Returns the remote ref (e.g., 'origin/feature-branch') or None if not tracking.
+    """
+    try:
+        result = run_git_quiet(
+            ["config", "--get", f"branch.{branch_name}.remote"], git_dir
+        )
+        remote = result.stdout.strip()
+        if not remote:
+            return None
+
+        result = run_git_quiet(
+            ["config", "--get", f"branch.{branch_name}.merge"], git_dir
+        )
+        merge_ref = result.stdout.strip()
+        if not merge_ref:
+            return None
+
+        # merge_ref is like refs/heads/branch-name, extract just the branch name
+        if merge_ref.startswith("refs/heads/"):
+            remote_branch = merge_ref[len("refs/heads/") :]
+        else:
+            remote_branch = merge_ref
+
+        return f"{remote}/{remote_branch}"
+    except subprocess.CalledProcessError:
+        return None
+
+
+def remote_branch_exists(remote_ref: str, git_dir: str) -> bool:
+    """Check if a remote branch exists (e.g., 'origin/feature-branch').
+
+    Args:
+        remote_ref: Full remote ref like 'origin/branch-name'
+        git_dir: Path to git directory
+    """
+    try:
+        run_git_quiet(["rev-parse", "--verify", f"refs/remotes/{remote_ref}"], git_dir)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def delete_remote_branch(branch_name: str, remote: str, git_dir: str) -> bool:
+    """Delete a branch from a remote.
+
+    Args:
+        branch_name: The branch name (without remote prefix)
+        remote: The remote name (e.g., 'origin')
+        git_dir: Path to git directory
+
+    Returns:
+        True if deletion succeeded, False otherwise
+    """
+    try:
+        run_git_command(["push", remote, "--delete", branch_name], git_dir)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def get_pr_state(branch_name: str) -> Optional[Tuple[str, bool]]:
+    """Check the PR state for a branch using GitHub CLI.
+
+    Returns:
+        Tuple of (state, is_merged) where state is 'OPEN', 'CLOSED', or 'MERGED',
+        or None if no PR exists or gh CLI is not available.
+
+    Note: This uses the gh CLI and works in any directory with a GitHub remote.
+    """
+    try:
+        # Use gh pr view to get PR info for this branch
+        result = subprocess.run(
+            ["gh", "pr", "view", branch_name, "--json", "state,mergedAt"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+
+        import json
+
+        data = json.loads(result.stdout)
+        state = data.get("state", "UNKNOWN")
+        merged_at = data.get("mergedAt")
+        is_merged = merged_at is not None
+
+        return (state, is_merged)
+    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError):
+        return None

--- a/gwtlib/branches.py
+++ b/gwtlib/branches.py
@@ -91,7 +91,31 @@ def remote_branch_exists(remote_ref: str, git_dir: str) -> bool:
         return False
 
 
-def delete_remote_branch(branch_name: str, remote: str, git_dir: str) -> bool:
+def can_delete_remote_branch(
+    branch_name: str, remote: str, git_dir: str
+) -> Tuple[bool, str]:
+    """Check if we can delete a remote branch (dry-run).
+
+    Args:
+        branch_name: The branch name (without remote prefix)
+        remote: The remote name (e.g., 'origin')
+        git_dir: Path to git directory
+
+    Returns:
+        Tuple of (can_delete, error_message). If can_delete is True, error_message is empty.
+    """
+    try:
+        # Use --dry-run to check without actually deleting
+        run_git_quiet(["push", "--dry-run", remote, "--delete", branch_name], git_dir)
+        return (True, "")
+    except subprocess.CalledProcessError as e:
+        error_msg = e.stderr.strip() if e.stderr else str(e)
+        return (False, error_msg)
+
+
+def delete_remote_branch(
+    branch_name: str, remote: str, git_dir: str
+) -> Tuple[bool, str]:
     """Delete a branch from a remote.
 
     Args:
@@ -100,13 +124,14 @@ def delete_remote_branch(branch_name: str, remote: str, git_dir: str) -> bool:
         git_dir: Path to git directory
 
     Returns:
-        True if deletion succeeded, False otherwise
+        Tuple of (success, error_message). If success is True, error_message is empty.
     """
     try:
         run_git_command(["push", remote, "--delete", branch_name], git_dir)
-        return True
-    except subprocess.CalledProcessError:
-        return False
+        return (True, "")
+    except subprocess.CalledProcessError as e:
+        error_msg = e.stderr.strip() if e.stderr else str(e)
+        return (False, error_msg)
 
 
 def get_pr_state(branch_name: str) -> Optional[Tuple[str, bool]]:

--- a/gwtlib/branches.py
+++ b/gwtlib/branches.py
@@ -1,6 +1,8 @@
 # gwtlib/branches.py
+from __future__ import annotations
+
 import subprocess
-from typing import Optional, Tuple
+from typing import Optional
 
 from gwtlib.git_ops import run_git_command, run_git_quiet
 
@@ -79,7 +81,7 @@ def remote_branch_exists(remote_ref: str, git_dir: str) -> bool:
 
 def can_delete_remote_branch(
     branch_name: str, remote: str, git_dir: str
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     """Check if we can delete a remote branch (dry-run).
 
     Args:
@@ -105,7 +107,7 @@ def can_delete_remote_branch(
 
 def delete_remote_branch(
     branch_name: str, remote: str, git_dir: str
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     """Delete a branch from a remote.
 
     Args:

--- a/gwtlib/cli.py
+++ b/gwtlib/cli.py
@@ -5,6 +5,7 @@ import sys
 
 from gwtlib.config import HAS_TOML, get_config_path, load_config, save_config
 from gwtlib.display import list_all_branches, list_worktrees
+from gwtlib.gc import gc_worktrees
 from gwtlib.resolution import get_git_dir, get_git_dir_with_source
 from gwtlib.worktrees import remove_worktree, switch_branch
 
@@ -100,6 +101,41 @@ def main():
     # Special command to get the default repository from config
     _get_repo_parser = subparsers.add_parser(
         "get-repo", help="Get the default repository from config (internal use)"
+    )
+
+    # Create a 'gc' subcommand for garbage collection
+    gc_parser = subparsers.add_parser(
+        "gc", help="Clean up stale worktrees (garbage collect)"
+    )
+    gc_parser.add_argument(
+        "--clean-days",
+        type=int,
+        default=7,
+        help="Days before a worktree is marked for cleaning (default: 7)",
+    )
+    gc_parser.add_argument(
+        "--delete-days",
+        type=int,
+        default=28,
+        help="Days before a worktree is marked for deletion (default: 28)",
+    )
+    gc_parser.add_argument(
+        "--clean-cmd",
+        type=str,
+        default=None,
+        help="Command to run for cleaning (default: 'just clean')",
+    )
+    gc_parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    gc_parser.add_argument(
+        "-p",
+        "--plan",
+        action="store_true",
+        help="Show plan only, don't execute",
     )
 
     args = parser.parse_args()
@@ -240,3 +276,12 @@ def main():
                 color=getattr(args, "color", "auto"),
                 absolute=getattr(args, "absolute", False),
             )
+    elif args.command == "gc":
+        gc_worktrees(
+            git_dir,
+            clean_days=getattr(args, "clean_days", 7),
+            delete_days=getattr(args, "delete_days", 28),
+            clean_cmd=getattr(args, "clean_cmd", None),
+            yes=getattr(args, "yes", False),
+            plan_only=getattr(args, "plan", False),
+        )

--- a/gwtlib/cli.py
+++ b/gwtlib/cli.py
@@ -126,7 +126,7 @@ def main():
         "--clean-cmd",
         type=str,
         default=None,
-        help="Command to run for cleaning (default: 'just clean')",
+        help="Command to run for cleaning (default: auto-detect or 'just clean')",
     )
     gc_parser.add_argument(
         "-y",

--- a/gwtlib/cli.py
+++ b/gwtlib/cli.py
@@ -12,6 +12,9 @@ from gwtlib.worktrees import remove_worktree, switch_branch
 
 def main():
     parser = argparse.ArgumentParser(description="Git worktree wrapper")
+    # NOTE: When adding new subcommands, also update the completion lists in:
+    #   - gwt.sh   (commands="...")
+    #   - gwt.fish (set -l commands ...)
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
     # Create a 'repo' subcommand

--- a/gwtlib/display.py
+++ b/gwtlib/display.py
@@ -19,6 +19,25 @@ class ColorMode:
     NEVER = "never"
 
 
+def prompt_yes_no(prompt: str, default: bool = False) -> bool:
+    """Prompt the user for a yes/no confirmation.
+
+    Args:
+        prompt: The prompt message (without the y/N suffix)
+        default: The default value if user just presses Enter
+
+    Returns:
+        True for yes, False for no
+    """
+    suffix = "(Y/n)" if default else "(y/N)"
+    print(f"{prompt} {suffix}: ", end="", file=sys.stderr)
+    sys.stderr.flush()
+    response = input().strip().lower()
+    if not response:
+        return default
+    return response in ("y", "yes")
+
+
 def format_worktree_rows(
     entries, git_dir, show_status=False, color_mode="auto", force_absolute=False
 ):
@@ -284,7 +303,7 @@ def list_all_branches(git_dir, mode="all", annotate=None):
             result = run_git_command(
                 ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_dir
             )
-            for branch in result.stdout.strip().split('\n'):
+            for branch in result.stdout.strip().split("\n"):
                 if branch:
                     branches.add(branch)
         except Exception:
@@ -296,10 +315,10 @@ def list_all_branches(git_dir, mode="all", annotate=None):
             result = run_git_command(
                 ["for-each-ref", "--format=%(refname:short)", "refs/remotes/"], git_dir
             )
-            for ref in result.stdout.strip().split('\n'):
-                if ref and '/' in ref:
+            for ref in result.stdout.strip().split("\n"):
+                if ref and "/" in ref:
                     # Extract branch name from remote/branch
-                    branch = ref.split('/', 1)[1]
+                    branch = ref.split("/", 1)[1]
                     branches.add(branch)
         except Exception:
             pass
@@ -317,7 +336,7 @@ def list_all_branches(git_dir, mode="all", annotate=None):
         result = run_git_command(
             ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_dir
         )
-        for branch in result.stdout.strip().split('\n'):
+        for branch in result.stdout.strip().split("\n"):
             if branch:
                 local_branches.add(branch)
     except Exception:

--- a/gwtlib/display.py
+++ b/gwtlib/display.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 
-from gwtlib.git_ops import is_worktree_dirty, run_git_command, run_git_quiet
+from gwtlib.git_ops import is_worktree_dirty, run_git_quiet
 from gwtlib.parsing import (
     get_worktree_list,
     parse_worktree_legacy,
@@ -276,7 +276,7 @@ def list_all_branches(git_dir, mode="all", annotate=None):
     # Get local branches (single fetch, used for both collection and categorization)
     local_branches = set()
     try:
-        result = run_git_command(
+        result = run_git_quiet(
             ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_dir
         )
         for branch in result.stdout.strip().split("\n"):
@@ -291,7 +291,7 @@ def list_all_branches(git_dir, mode="all", annotate=None):
     # Add remote branches (without remote prefix for completion)
     if mode == "all":
         try:
-            result = run_git_command(
+            result = run_git_quiet(
                 ["for-each-ref", "--format=%(refname:short)", "refs/remotes/"], git_dir
             )
             for ref in result.stdout.strip().split("\n"):

--- a/gwtlib/display.py
+++ b/gwtlib/display.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 
-from gwtlib.git_ops import run_git_command, run_git_in_worktree, run_git_quiet
+from gwtlib.git_ops import is_worktree_dirty, run_git_command, run_git_quiet
 from gwtlib.parsing import (
     get_worktree_list,
     parse_worktree_legacy,
@@ -17,25 +17,6 @@ class ColorMode:
     AUTO = "auto"
     ALWAYS = "always"
     NEVER = "never"
-
-
-def prompt_yes_no(prompt: str, default: bool = False) -> bool:
-    """Prompt the user for a yes/no confirmation.
-
-    Args:
-        prompt: The prompt message (without the y/N suffix)
-        default: The default value if user just presses Enter
-
-    Returns:
-        True for yes, False for no
-    """
-    suffix = "(Y/n)" if default else "(y/N)"
-    print(f"{prompt} {suffix}: ", end="", file=sys.stderr)
-    sys.stderr.flush()
-    response = input().strip().lower()
-    if not response:
-        return default
-    return response in ("y", "yes")
 
 
 def format_worktree_rows(
@@ -67,11 +48,7 @@ def format_worktree_rows(
     def is_dirty(path):
         if not show_status:
             return False
-        try:
-            r = run_git_in_worktree(["status", "--porcelain", "-uno"], path)
-            return bool(r.stdout.strip())
-        except subprocess.CalledProcessError:
-            return False
+        return is_worktree_dirty(path, include_untracked=False)
 
     # Sorting: current first, main second, others by branch (case-insensitive)
     def sort_key(e):
@@ -252,19 +229,6 @@ def list_all_branches(git_dir, mode="all", annotate=None):
         mode: "all", "local", "worktrees"
         annotate: None | "bash" | "fish"
     """
-    branches = set()
-
-    # Collect worktree branches (exclude main for worktrees mode)
-    if mode in ["all", "worktrees"]:
-        include_main_wt = mode == "all"
-        worktrees = get_worktree_list(
-            git_dir, include_main=include_main_wt, warnings=[]
-        )
-        wt_branches = []
-        for wt in worktrees:
-            if wt["branch"]:
-                branches.add(wt["branch"])
-                wt_branches.append(wt["branch"])
 
     # Helper function to print branch with annotation
     def print_branch(b, kind):
@@ -291,23 +255,35 @@ def list_all_branches(git_dir, mode="all", annotate=None):
         else:
             print(b)
 
+    # Get worktree branches (always needed for categorization)
+    worktree_branches = {
+        wt["branch"]
+        for wt in get_worktree_list(git_dir, include_main=True, warnings=[])
+        if wt.get("branch")
+    }
+
+    # For worktrees mode, just print worktree branches (excluding main)
     if mode == "worktrees":
-        # Only print worktree branch names (excluding main)
+        worktrees = get_worktree_list(git_dir, include_main=False, warnings=[])
+        wt_branches = [wt["branch"] for wt in worktrees if wt.get("branch")]
         for b in sorted(wt_branches):
             print_branch(b, "worktree")
         return
 
-    # Add local branches
-    if mode in ["all", "local"]:
-        try:
-            result = run_git_command(
-                ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_dir
-            )
-            for branch in result.stdout.strip().split("\n"):
-                if branch:
-                    branches.add(branch)
-        except Exception:
-            pass
+    # Get local branches (single fetch, used for both collection and categorization)
+    local_branches = set()
+    try:
+        result = run_git_command(
+            ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_dir
+        )
+        for branch in result.stdout.strip().split("\n"):
+            if branch:
+                local_branches.add(branch)
+    except Exception:
+        pass
+
+    # Collect all branches
+    branches = set(local_branches)
 
     # Add remote branches (without remote prefix for completion)
     if mode == "all":
@@ -322,25 +298,6 @@ def list_all_branches(git_dir, mode="all", annotate=None):
                     branches.add(branch)
         except Exception:
             pass
-
-    # Get branch categories for proper ordering (include main for mode="all")
-    worktree_branches = {
-        wt["branch"]
-        for wt in get_worktree_list(git_dir, include_main=True, warnings=[])
-        if wt.get("branch")
-    }
-
-    # Get local branches
-    local_branches = set()
-    try:
-        result = run_git_command(
-            ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_dir
-        )
-        for branch in result.stdout.strip().split("\n"):
-            if branch:
-                local_branches.add(branch)
-    except Exception:
-        pass
 
     # Categorize branches
     worktree_list = sorted([b for b in branches if b in worktree_branches])

--- a/gwtlib/display.py
+++ b/gwtlib/display.py
@@ -270,6 +270,9 @@ def list_all_branches(git_dir, mode="all", annotate=None):
             print_branch(b, "worktree")
         return
 
+    # Track failures for batched warning at end
+    fetch_failures = []
+
     # Get local branches (single fetch, used for both collection and categorization)
     local_branches = set()
     try:
@@ -279,8 +282,8 @@ def list_all_branches(git_dir, mode="all", annotate=None):
         for branch in result.stdout.strip().split("\n"):
             if branch:
                 local_branches.add(branch)
-    except Exception:
-        pass
+    except Exception as e:
+        fetch_failures.append(f"local branches: {e}")
 
     # Collect all branches
     branches = set(local_branches)
@@ -296,8 +299,8 @@ def list_all_branches(git_dir, mode="all", annotate=None):
                     # Extract branch name from remote/branch
                     branch = ref.split("/", 1)[1]
                     branches.add(branch)
-        except Exception:
-            pass
+        except Exception as e:
+            fetch_failures.append(f"remote branches: {e}")
 
     # Categorize branches
     worktree_list = sorted([b for b in branches if b in worktree_branches])
@@ -313,3 +316,11 @@ def list_all_branches(git_dir, mode="all", annotate=None):
         print_branch(branch, "local")
     for branch in remote_only_list:
         print_branch(branch, "remote")
+
+    # Log batched warnings at end (first 10)
+    if fetch_failures:
+        failures_to_show = fetch_failures[:10]
+        print(
+            f"Warning: failed to fetch {', '.join(failures_to_show)}",
+            file=sys.stderr,
+        )

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import List, Optional
 
 try:
     from tqdm import tqdm
@@ -368,7 +368,7 @@ def execute_gc_plan(
         for wt in plan.to_clean:
             print(f"\n{wt.branch}:", file=sys.stderr)
             if dry_run:
-                print(f"  Would run clean command", file=sys.stderr)
+                print("  Would run clean command", file=sys.stderr)
             else:
                 run_clean_command(wt.path, git_dir, clean_cmd)
 
@@ -378,7 +378,7 @@ def execute_gc_plan(
         for wt in plan.to_delete:
             print(f"\n{wt.branch}:", file=sys.stderr)
             if dry_run:
-                print(f"  Would remove worktree", file=sys.stderr)
+                print("  Would remove worktree", file=sys.stderr)
             else:
                 try:
                     # Use git worktree remove directly since we know it's clean
@@ -387,7 +387,7 @@ def execute_gc_plan(
                         git_dir,
                         capture=False,
                     )
-                    print(f"  Removed worktree", file=sys.stderr)
+                    print("  Removed worktree", file=sys.stderr)
 
                     # Also delete the local branch
                     try:

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -1,0 +1,474 @@
+# gwtlib/gc.py
+"""Garbage collection for stale worktrees."""
+
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+try:
+    from tqdm import tqdm
+
+    HAS_TQDM = True
+except ImportError:
+    HAS_TQDM = False
+    tqdm = None  # type: ignore
+
+from gwtlib.config import get_repo_config
+from gwtlib.display import prompt_yes_no
+from gwtlib.git_ops import run_git_command, run_git_quiet
+from gwtlib.parsing import get_worktree_list
+from gwtlib.paths import rel_display_path
+from gwtlib.worktrees import _is_worktree_dirty
+
+
+def _get_main_branch_name_quiet(git_dir: str) -> Optional[str]:
+    """Get main branch name without printing output."""
+    try:
+        result = run_git_quiet(["worktree", "list"], git_dir)
+        lines = result.stdout.splitlines()
+        if lines:
+            parts = lines[0].split()
+            if len(parts) >= 3:
+                return parts[2].strip("[]")
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+
+def _is_branch_merged_to_main(branch_name: str, git_dir: str) -> bool:
+    """Check if a branch has been merged to main.
+
+    Returns True if all commits in the branch are also in main.
+    """
+    main_branch = _get_main_branch_name_quiet(git_dir)
+    if not main_branch:
+        # Can't determine main branch, assume not merged to be safe
+        return False
+
+    try:
+        # Check if there are any commits in branch that aren't in main
+        result = run_git_quiet(
+            ["log", f"{main_branch}..{branch_name}", "--oneline"],
+            git_dir,
+        )
+        # If no output, branch is fully merged
+        return not result.stdout.strip()
+    except subprocess.CalledProcessError:
+        # Error checking, assume not merged to be safe
+        return False
+
+
+# Default thresholds in seconds
+CLEAN_THRESHOLD_DAYS = 7
+DELETE_THRESHOLD_DAYS = 28
+
+
+@dataclass
+class WorktreeInfo:
+    """Information about a worktree for garbage collection."""
+
+    path: str
+    branch: str
+    mtime: float  # Most recent modification time (Unix timestamp)
+    age_days: float  # Age in days since last modification
+    is_dirty: bool
+    is_merged: bool  # True if branch is merged to main
+    is_main: bool = False
+
+
+def get_worktree_mtime(worktree_path: str) -> float:
+    """Get the most recent modification time of any file in a worktree.
+
+    Walks the directory tree and finds the most recently modified file,
+    excluding .git directory.
+
+    Returns:
+        Unix timestamp of most recent modification.
+    """
+    most_recent = 0.0
+    worktree_path = os.path.abspath(worktree_path)
+
+    for root, dirs, files in os.walk(worktree_path):
+        # Skip .git directory
+        if ".git" in dirs:
+            dirs.remove(".git")
+
+        # Check directory modification time
+        try:
+            dir_mtime = os.path.getmtime(root)
+            most_recent = max(most_recent, dir_mtime)
+        except OSError:
+            pass
+
+        # Check file modification times
+        for filename in files:
+            try:
+                filepath = os.path.join(root, filename)
+                file_mtime = os.path.getmtime(filepath)
+                most_recent = max(most_recent, file_mtime)
+            except OSError:
+                pass
+
+    return most_recent
+
+
+def get_worktree_info_list(
+    git_dir: str, include_main: bool = False
+) -> List[WorktreeInfo]:
+    """Get information about all worktrees including modification times.
+
+    Args:
+        git_dir: Path to the git directory.
+        include_main: Whether to include the main worktree.
+
+    Returns:
+        List of WorktreeInfo objects sorted by age (oldest first).
+    """
+    worktrees = get_worktree_list(git_dir, include_main=include_main)
+    current_time = time.time()
+    info_list = []
+
+    # Show progress
+    if HAS_TQDM and tqdm is not None:
+        iterator = tqdm(  # type: ignore[misc]
+            worktrees,
+            desc="Scanning",
+            file=sys.stderr,
+            unit="worktree",
+        )
+    else:
+        iterator = worktrees
+
+    for wt in iterator:
+        path = wt["path"]
+        branch = wt.get("branch", "")
+
+        # Skip if path doesn't exist
+        if not os.path.isdir(path):
+            continue
+
+        mtime = get_worktree_mtime(path)
+        age_seconds = current_time - mtime
+        age_days = age_seconds / (24 * 60 * 60)
+
+        info = WorktreeInfo(
+            path=path,
+            branch=branch,
+            mtime=mtime,
+            age_days=age_days,
+            is_dirty=_is_worktree_dirty(path),
+            is_merged=_is_branch_merged_to_main(branch, git_dir),
+            is_main=wt.get("is_main", False),
+        )
+        info_list.append(info)
+
+    # Sort by age (oldest first)
+    info_list.sort(key=lambda x: -x.age_days)
+    return info_list
+
+
+@dataclass
+class GcPlan:
+    """Plan for garbage collection."""
+
+    to_clean: List[WorktreeInfo]  # Worktrees > clean_days old, to run clean command
+    to_delete: List[WorktreeInfo]  # Worktrees > delete_days old, clean, and merged
+    dirty: List[WorktreeInfo]  # Worktrees > delete_days old but dirty
+    unmerged: List[WorktreeInfo]  # Worktrees > delete_days old, clean, but not merged
+    skip: List[WorktreeInfo]  # Other worktrees (< clean_days old)
+
+
+def create_gc_plan(
+    git_dir: str,
+    clean_days: int = CLEAN_THRESHOLD_DAYS,
+    delete_days: int = DELETE_THRESHOLD_DAYS,
+) -> GcPlan:
+    """Create a garbage collection plan.
+
+    Args:
+        git_dir: Path to the git directory.
+        clean_days: Threshold for cleaning (default 7 days).
+        delete_days: Threshold for deletion (default 28 days).
+
+    Returns:
+        GcPlan with categorized worktrees.
+    """
+    worktrees = get_worktree_info_list(git_dir, include_main=False)
+
+    to_clean = []
+    to_delete = []
+    dirty = []
+    unmerged = []
+    skip = []
+
+    for wt in worktrees:
+        if wt.age_days >= delete_days:
+            # Old enough for deletion
+            if wt.is_dirty:
+                dirty.append(wt)
+                to_clean.append(wt)  # Still clean dirty worktrees
+            elif not wt.is_merged:
+                unmerged.append(wt)
+                to_clean.append(wt)  # Still clean unmerged worktrees
+            else:
+                to_delete.append(wt)
+        elif wt.age_days >= clean_days:
+            # Old enough for cleaning but not deletion
+            to_clean.append(wt)
+        else:
+            # Too recent, skip
+            skip.append(wt)
+
+    return GcPlan(
+        to_clean=to_clean,
+        to_delete=to_delete,
+        dirty=dirty,
+        unmerged=unmerged,
+        skip=skip,
+    )
+
+
+def format_age(days: float) -> str:
+    """Format age in days."""
+    if days < 1:
+        return "<1d"
+    return f"{int(days)}d"
+
+
+def _path_matches_branch(path: str, branch: str, git_dir: str) -> bool:
+    """Check if the worktree path is the expected .gwt/{branch} location."""
+    from gwtlib.paths import get_worktree_base
+
+    expected = os.path.join(get_worktree_base(git_dir), branch)
+    return os.path.abspath(path) == os.path.abspath(expected)
+
+
+def _format_worktree_line(wt: WorktreeInfo, git_dir: str, suffix: str = "") -> str:
+    """Format a single worktree as one line."""
+    age = format_age(wt.age_days)
+    # Only show path if it doesn't match expected location
+    if _path_matches_branch(wt.path, wt.branch, git_dir):
+        return f"  {wt.branch}  ({age}){suffix}"
+    else:
+        path_display = rel_display_path(wt.path, git_dir, force_absolute=False)
+        return f"  {wt.branch}  ({age}){suffix}  [{path_display}]"
+
+
+def print_plan(plan: GcPlan, git_dir: str, clean_days: int, delete_days: int) -> None:
+    """Print the garbage collection plan to stderr."""
+    total = (
+        len(plan.to_clean)
+        + len(plan.to_delete)
+        + len(plan.dirty)
+        + len(plan.unmerged)
+        + len(plan.skip)
+    )
+
+    if total == 0:
+        print("No worktrees found.", file=sys.stderr)
+        return
+
+    # Check if nothing to do
+    if (
+        not plan.to_clean
+        and not plan.to_delete
+        and not plan.dirty
+        and not plan.unmerged
+    ):
+        print(f"All {len(plan.skip)} worktree(s) are recent.", file=sys.stderr)
+        return
+
+    # Print worktrees to clean (run clean command)
+    if plan.to_clean:
+        print(
+            f"\nWill clean {len(plan.to_clean)} worktrees over {clean_days} days old:",
+            file=sys.stderr,
+        )
+        for wt in plan.to_clean:
+            suffix = " [dirty]" if wt.is_dirty else ""
+            print(_format_worktree_line(wt, git_dir, suffix), file=sys.stderr)
+
+    # Print worktrees to delete
+    if plan.to_delete:
+        print(
+            f"\nWill delete {len(plan.to_delete)} worktrees over {delete_days} days old:",
+            file=sys.stderr,
+        )
+        for wt in plan.to_delete:
+            print(_format_worktree_line(wt, git_dir), file=sys.stderr)
+
+    # Print dirty worktrees that can't be deleted
+    if plan.dirty:
+        print(
+            f"\nOld but dirty, inspect manually ({len(plan.dirty)}):", file=sys.stderr
+        )
+        for wt in plan.dirty:
+            print(_format_worktree_line(wt, git_dir), file=sys.stderr)
+
+    # Print unmerged worktrees that can't be auto-deleted
+    if plan.unmerged:
+        print(
+            f"\nOld but unmerged, inspect manually ({len(plan.unmerged)}):",
+            file=sys.stderr,
+        )
+        for wt in plan.unmerged:
+            print(_format_worktree_line(wt, git_dir), file=sys.stderr)
+
+    # Summary
+    print("", file=sys.stderr)
+    if plan.skip:
+        print(f"Keeping {len(plan.skip)} recent worktree(s)", file=sys.stderr)
+
+
+def run_clean_command(
+    worktree_path: str, git_dir: str, clean_cmd: str | None = None
+) -> bool:
+    """Run a clean command in a worktree.
+
+    Args:
+        worktree_path: Path to the worktree.
+        git_dir: Path to the git directory.
+        clean_cmd: Custom clean command, or None for default.
+
+    Returns:
+        True if command succeeded, False otherwise.
+    """
+    # Get clean command from config or use default
+    if clean_cmd is None:
+        repo_config = get_repo_config(git_dir)
+        clean_cmd = str(repo_config.get("clean_command", "just clean"))
+
+    current_dir = os.getcwd()
+    try:
+        os.chdir(worktree_path)
+        print(f"  Running: {clean_cmd}", file=sys.stderr)
+        result = subprocess.run(
+            clean_cmd,  # type: ignore[arg-type]
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            if result.stderr:
+                print(f"  Warning: {result.stderr.strip()}", file=sys.stderr)
+            return False
+        return True
+    except Exception as e:
+        print(f"  Error running clean command: {e}", file=sys.stderr)
+        return False
+    finally:
+        os.chdir(current_dir)
+
+
+def execute_gc_plan(
+    plan: GcPlan,
+    git_dir: str,
+    clean_cmd: Optional[str] = None,
+    dry_run: bool = False,
+) -> None:
+    """Execute the garbage collection plan.
+
+    Args:
+        plan: The GcPlan to execute.
+        git_dir: Path to the git directory.
+        clean_cmd: Custom clean command for cleaning.
+        dry_run: If True, only print what would be done.
+    """
+    # Run clean commands
+    if plan.to_clean:
+        print("\nCleaning worktrees...", file=sys.stderr)
+        for wt in plan.to_clean:
+            print(f"\n{wt.branch}:", file=sys.stderr)
+            if dry_run:
+                print(f"  Would run clean command", file=sys.stderr)
+            else:
+                run_clean_command(wt.path, git_dir, clean_cmd)
+
+    # Delete old worktrees
+    if plan.to_delete:
+        print("\nRemoving worktrees...", file=sys.stderr)
+        for wt in plan.to_delete:
+            print(f"\n{wt.branch}:", file=sys.stderr)
+            if dry_run:
+                print(f"  Would remove worktree", file=sys.stderr)
+            else:
+                try:
+                    # Use git worktree remove directly since we know it's clean
+                    run_git_command(
+                        ["worktree", "remove", wt.path],
+                        git_dir,
+                        capture=False,
+                    )
+                    print(f"  Removed worktree", file=sys.stderr)
+
+                    # Also delete the local branch
+                    try:
+                        run_git_command(
+                            ["branch", "-d", wt.branch],
+                            git_dir,
+                            capture=False,
+                        )
+                        print(f"  Deleted branch '{wt.branch}'", file=sys.stderr)
+                    except subprocess.CalledProcessError:
+                        # Branch might not be fully merged, try force delete
+                        try:
+                            run_git_command(
+                                ["branch", "-D", wt.branch],
+                                git_dir,
+                                capture=False,
+                            )
+                            print(
+                                f"  Force-deleted branch '{wt.branch}'", file=sys.stderr
+                            )
+                        except subprocess.CalledProcessError as e:
+                            print(f"  Could not delete branch: {e}", file=sys.stderr)
+                except subprocess.CalledProcessError as e:
+                    print(f"  Error removing worktree: {e}", file=sys.stderr)
+
+    print("\nDone.", file=sys.stderr)
+
+
+def gc_worktrees(
+    git_dir: str,
+    clean_days: int = CLEAN_THRESHOLD_DAYS,
+    delete_days: int = DELETE_THRESHOLD_DAYS,
+    clean_cmd: Optional[str] = None,
+    yes: bool = False,
+    plan_only: bool = False,
+) -> None:
+    """Run garbage collection on worktrees.
+
+    Args:
+        git_dir: Path to the git directory.
+        clean_days: Threshold in days for cleaning (default 7).
+        delete_days: Threshold in days for deletion (default 28).
+        clean_cmd: Custom clean command.
+        yes: Skip confirmation prompt.
+        plan_only: Only print plan, don't execute.
+    """
+    # Create the plan
+    plan = create_gc_plan(git_dir, clean_days=clean_days, delete_days=delete_days)
+
+    # Print the plan
+    print_plan(plan, git_dir, clean_days=clean_days, delete_days=delete_days)
+
+    # Check if there's anything to do
+    if not plan.to_clean and not plan.to_delete:
+        return
+
+    # Plan only mode - just exit after printing
+    if plan_only:
+        return
+
+    # Prompt for confirmation
+    if not yes:
+        print("", file=sys.stderr)
+        if not prompt_yes_no("Proceed?"):
+            print("Aborted.", file=sys.stderr)
+            return
+
+    # Execute the plan
+    execute_gc_plan(plan, git_dir, clean_cmd=clean_cmd, dry_run=False)

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -412,9 +412,8 @@ def execute_gc_plan(
                     )
                     print("  Removed worktree", file=sys.stderr)
 
-                    # Also delete the local branch
-                    # Use -d first (safe delete), fall back to -D only if branch
-                    # is merged to main but not to current HEAD
+                    # Delete the local branch (safe delete only)
+                    # If -d fails, branch state changed since planning - keep it for manual inspection
                     try:
                         run_git_command(
                             ["branch", "-d", wt.branch],
@@ -423,20 +422,10 @@ def execute_gc_plan(
                         )
                         print(f"  Deleted branch '{wt.branch}'", file=sys.stderr)
                     except subprocess.CalledProcessError:
-                        # Branch is merged to main (verified during planning) but
-                        # not to current HEAD. Safe to force-delete.
-                        try:
-                            run_git_command(
-                                ["branch", "-D", wt.branch],
-                                git_dir,
-                                capture=False,
-                            )
-                            print(
-                                f"  Deleted branch '{wt.branch}' (merged to main, not HEAD)",
-                                file=sys.stderr,
-                            )
-                        except subprocess.CalledProcessError as e:
-                            print(f"  Could not delete branch: {e}", file=sys.stderr)
+                        print(
+                            f"  Keeping branch '{wt.branch}': not safely deletable (may have diverged since planning)",
+                            file=sys.stderr,
+                        )
                 except subprocess.CalledProcessError as e:
                     print(f"  Error removing worktree: {e}", file=sys.stderr)
 

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -68,7 +68,9 @@ def get_worktree_mtime(worktree_path: str) -> float:
     """Get the most recent modification time of any file in a worktree.
 
     Walks the directory tree and finds the most recently modified file,
-    excluding .git directory.
+    excluding:
+    - .git directory/file (git internal state changes aren't real work)
+    - Directory mtimes (change during housekeeping like `just clean`)
 
     Returns:
         Unix timestamp of most recent modification.
@@ -81,15 +83,11 @@ def get_worktree_mtime(worktree_path: str) -> float:
         if ".git" in dirs:
             dirs.remove(".git")
 
-        # Check directory modification time
-        try:
-            dir_mtime = os.path.getmtime(root)
-            most_recent = max(most_recent, dir_mtime)
-        except OSError:
-            pass
-
-        # Check file modification times
+        # Check file modification times (excluding .git file in worktrees)
         for filename in files:
+            # Skip .git file (worktrees have a .git file pointing to the real git dir)
+            if filename == ".git" and root == worktree_path:
+                continue
             try:
                 filepath = os.path.join(root, filename)
                 file_mtime = os.path.getmtime(filepath)
@@ -397,6 +395,8 @@ def execute_gc_plan(
                     print("  Removed worktree", file=sys.stderr)
 
                     # Also delete the local branch
+                    # Use -d first (safe delete), fall back to -D only if branch
+                    # is merged to main but not to current HEAD
                     try:
                         run_git_command(
                             ["branch", "-d", wt.branch],
@@ -405,7 +405,8 @@ def execute_gc_plan(
                         )
                         print(f"  Deleted branch '{wt.branch}'", file=sys.stderr)
                     except subprocess.CalledProcessError:
-                        # Branch might not be fully merged, try force delete
+                        # Branch is merged to main (verified during planning) but
+                        # not to current HEAD. Safe to force-delete.
                         try:
                             run_git_command(
                                 ["branch", "-D", wt.branch],
@@ -413,7 +414,8 @@ def execute_gc_plan(
                                 capture=False,
                             )
                             print(
-                                f"  Force-deleted branch '{wt.branch}'", file=sys.stderr
+                                f"  Deleted branch '{wt.branch}' (merged to main, not HEAD)",
+                                file=sys.stderr,
                             )
                         except subprocess.CalledProcessError as e:
                             print(f"  Could not delete branch: {e}", file=sys.stderr)

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -380,6 +380,13 @@ def execute_gc_plan(
             if dry_run:
                 print("  Would remove worktree", file=sys.stderr)
             else:
+                # Re-check dirtiness to avoid TOCTOU race
+                if is_worktree_dirty(wt.path):
+                    print(
+                        "  Skipping: worktree became dirty since planning",
+                        file=sys.stderr,
+                    )
+                    continue
                 try:
                     # Use git worktree remove directly since we know it's clean
                     run_git_command(

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -72,10 +72,14 @@ def get_worktree_mtime(worktree_path: str) -> float:
     - .git directory/file (git internal state changes aren't real work)
     - Directory mtimes (change during housekeeping like `just clean`)
 
+    Fallback order for empty worktrees:
+    1. .git file mtime (reflects worktree creation, unaffected by housekeeping)
+    2. Directory mtime (last resort)
+
     Returns:
         Unix timestamp of most recent modification.
     """
-    most_recent = 0.0
+    most_recent: float | None = None
     worktree_path = os.path.abspath(worktree_path)
 
     for root, dirs, files in os.walk(worktree_path):
@@ -91,10 +95,24 @@ def get_worktree_mtime(worktree_path: str) -> float:
             try:
                 filepath = os.path.join(root, filename)
                 file_mtime = os.path.getmtime(filepath)
-                most_recent = max(most_recent, file_mtime)
+                most_recent = (
+                    file_mtime if most_recent is None else max(most_recent, file_mtime)
+                )
             except OSError:
                 pass
 
+    # Fallback to .git file mtime (reflects worktree creation, not housekeeping)
+    if most_recent is None:
+        git_file = os.path.join(worktree_path, ".git")
+        try:
+            return os.path.getmtime(git_file)
+        except OSError:
+            pass
+        # Last resort: directory mtime
+        try:
+            return os.path.getmtime(worktree_path)
+        except OSError:
+            return 0.0
     return most_recent
 
 

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -46,7 +46,7 @@ def _is_branch_merged_to_main(branch_name: str, git_dir: str) -> bool:
         return False
 
 
-# Default thresholds in seconds
+# Default thresholds
 CLEAN_THRESHOLD_DAYS = 7
 DELETE_THRESHOLD_DAYS = 28
 

--- a/gwtlib/gc.py
+++ b/gwtlib/gc.py
@@ -17,25 +17,10 @@ except ImportError:
     tqdm = None  # type: ignore
 
 from gwtlib.config import get_repo_config
-from gwtlib.display import prompt_yes_no
-from gwtlib.git_ops import run_git_command, run_git_quiet
-from gwtlib.parsing import get_worktree_list
+from gwtlib.git_ops import is_worktree_dirty, run_git_command, run_git_quiet
+from gwtlib.parsing import get_main_branch_name, get_worktree_list
 from gwtlib.paths import rel_display_path
-from gwtlib.worktrees import _is_worktree_dirty
-
-
-def _get_main_branch_name_quiet(git_dir: str) -> Optional[str]:
-    """Get main branch name without printing output."""
-    try:
-        result = run_git_quiet(["worktree", "list"], git_dir)
-        lines = result.stdout.splitlines()
-        if lines:
-            parts = lines[0].split()
-            if len(parts) >= 3:
-                return parts[2].strip("[]")
-    except subprocess.CalledProcessError:
-        pass
-    return None
+from gwtlib.ui import prompt_yes_no
 
 
 def _is_branch_merged_to_main(branch_name: str, git_dir: str) -> bool:
@@ -43,7 +28,7 @@ def _is_branch_merged_to_main(branch_name: str, git_dir: str) -> bool:
 
     Returns True if all commits in the branch are also in main.
     """
-    main_branch = _get_main_branch_name_quiet(git_dir)
+    main_branch = get_main_branch_name(git_dir)
     if not main_branch:
         # Can't determine main branch, assume not merged to be safe
         return False
@@ -159,7 +144,7 @@ def get_worktree_info_list(
             branch=branch,
             mtime=mtime,
             age_days=age_days,
-            is_dirty=_is_worktree_dirty(path),
+            is_dirty=is_worktree_dirty(path),
             is_merged=_is_branch_merged_to_main(branch, git_dir),
             is_main=wt.get("is_main", False),
         )

--- a/gwtlib/git_ops.py
+++ b/gwtlib/git_ops.py
@@ -3,6 +3,27 @@ import subprocess
 import sys
 
 
+def is_worktree_dirty(worktree_path: str, include_untracked: bool = True) -> bool:
+    """Check if worktree has uncommitted changes.
+
+    Args:
+        worktree_path: Path to the worktree directory.
+        include_untracked: If True, include untracked files in the check.
+                          If False, only check tracked files (uses -uno flag).
+
+    Returns:
+        True if the worktree has uncommitted changes, False otherwise.
+    """
+    try:
+        cmd = ["git", "-C", worktree_path, "status", "--porcelain"]
+        if not include_untracked:
+            cmd.append("-uno")
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        return bool(result.stdout.strip())
+    except subprocess.CalledProcessError:
+        return False
+
+
 def run_git_command(cmd_args, git_dir, capture=True):
     """Execute git commands with specified git directory."""
     cmd = ["git", f"--git-dir={git_dir}"] + cmd_args

--- a/gwtlib/git_ops.py
+++ b/gwtlib/git_ops.py
@@ -20,8 +20,9 @@ def is_worktree_dirty(worktree_path: str, include_untracked: bool = True) -> boo
             cmd.append("-uno")
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
         return bool(result.stdout.strip())
-    except subprocess.CalledProcessError:
-        return False
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: git status failed for {worktree_path}: {e}", file=sys.stderr)
+        return True  # Fail closed: assume dirty if we can't check
 
 
 def run_git_command(cmd_args, git_dir, capture=True):

--- a/gwtlib/github.py
+++ b/gwtlib/github.py
@@ -1,0 +1,35 @@
+# gwtlib/github.py
+"""GitHub CLI integrations."""
+
+import json
+import subprocess
+from typing import Optional, Tuple
+
+
+def get_pr_state(branch_name: str) -> Optional[Tuple[str, bool]]:
+    """Check the PR state for a branch using GitHub CLI.
+
+    Returns:
+        Tuple of (state, is_merged) where state is 'OPEN', 'CLOSED', or 'MERGED',
+        or None if no PR exists or gh CLI is not available.
+
+    Note: This uses the gh CLI and works in any directory with a GitHub remote.
+    """
+    try:
+        # Use gh pr view to get PR info for this branch
+        result = subprocess.run(
+            ["gh", "pr", "view", branch_name, "--json", "state,mergedAt"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        state = data.get("state", "UNKNOWN")
+        merged_at = data.get("mergedAt")
+        is_merged = merged_at is not None
+
+        return (state, is_merged)
+    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError):
+        return None

--- a/gwtlib/github.py
+++ b/gwtlib/github.py
@@ -5,17 +5,26 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from typing import Optional
 
 
-def get_pr_state(branch_name: str) -> Optional[tuple[str, bool]]:
+def get_pr_state(
+    branch_name: str, cwd: Optional[str] = None
+) -> Optional[tuple[str, bool]]:
     """Check the PR state for a branch using GitHub CLI.
+
+    Args:
+        branch_name: The branch to check for PRs.
+        cwd: Directory to run gh from (should be inside the git repo).
+             If None, uses current directory.
 
     Returns:
         Tuple of (state, is_merged) where state is 'OPEN', 'CLOSED', or 'MERGED',
-        or None if no PR exists or gh CLI is not available.
+        or None if no PR exists for this branch.
 
-    Note: This uses the gh CLI and works in any directory with a GitHub remote.
+    Note: Requires gh CLI and must be run from within a git repo with a GitHub remote,
+    or cwd must point to such a directory.
     """
     try:
         # Use gh pr view to get PR info for this branch
@@ -23,8 +32,21 @@ def get_pr_state(branch_name: str) -> Optional[tuple[str, bool]]:
             ["gh", "pr", "view", branch_name, "--json", "state,mergedAt"],
             capture_output=True,
             text=True,
+            check=False,
+            cwd=cwd,
         )
         if result.returncode != 0:
+            stderr = result.stderr.lower()
+            # "no pull requests found" means no PR exists - not an error
+            if "no pull requests found" in stderr:
+                return None
+            # Other failures (not in a repo, no gh CLI, network error, etc.)
+            # Log warning so user knows GitHub lookup failed
+            if result.stderr.strip():
+                print(
+                    f"Warning: GitHub PR lookup failed: {result.stderr.strip()}",
+                    file=sys.stderr,
+                )
             return None
 
         data = json.loads(result.stdout)
@@ -33,5 +55,10 @@ def get_pr_state(branch_name: str) -> Optional[tuple[str, bool]]:
         is_merged = merged_at is not None
 
         return (state, is_merged)
-    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError:
+        # gh CLI not installed
+        print("Warning: gh CLI not found, skipping PR lookup", file=sys.stderr)
+        return None
+    except json.JSONDecodeError:
+        print("Warning: Failed to parse gh CLI output", file=sys.stderr)
         return None

--- a/gwtlib/github.py
+++ b/gwtlib/github.py
@@ -1,12 +1,14 @@
 # gwtlib/github.py
 """GitHub CLI integrations."""
 
+from __future__ import annotations
+
 import json
 import subprocess
-from typing import Optional, Tuple
+from typing import Optional
 
 
-def get_pr_state(branch_name: str) -> Optional[Tuple[str, bool]]:
+def get_pr_state(branch_name: str) -> Optional[tuple[str, bool]]:
     """Check the PR state for a branch using GitHub CLI.
 
     Returns:

--- a/gwtlib/parsing.py
+++ b/gwtlib/parsing.py
@@ -26,7 +26,11 @@ def get_main_branch_name(git_dir: str) -> Optional[str]:
         if lines:
             parts = lines[0].split()
             if len(parts) >= 3:
-                return parts[2].strip("[]")
+                branch = parts[2].strip("[]")
+                # Return None if main worktree is in detached HEAD state
+                if branch.startswith("(") or "detached" in branch.lower():
+                    return None
+                return branch
     except subprocess.CalledProcessError:
         pass
     return None

--- a/gwtlib/parsing.py
+++ b/gwtlib/parsing.py
@@ -2,9 +2,34 @@
 import os
 import subprocess
 import sys
+from typing import Optional
 
 from gwtlib.git_ops import run_git_in_worktree, run_git_quiet
 from gwtlib.paths import get_worktree_base
+
+
+def get_main_branch_name(git_dir: str) -> Optional[str]:
+    """Extract the main branch name from git worktree list.
+
+    Parses the first line of `git worktree list` output to find the main branch.
+    The main worktree is always listed first and shows the branch name in brackets.
+
+    Args:
+        git_dir: Path to the git directory.
+
+    Returns:
+        The main branch name (e.g., 'main' or 'master'), or None if it cannot be determined.
+    """
+    try:
+        result = run_git_quiet(["worktree", "list"], git_dir)
+        lines = result.stdout.splitlines()
+        if lines:
+            parts = lines[0].split()
+            if len(parts) >= 3:
+                return parts[2].strip("[]")
+    except subprocess.CalledProcessError:
+        pass
+    return None
 
 
 def parse_worktree_porcelain(git_dir, include_main=True):
@@ -146,31 +171,20 @@ def get_git_worktrees(git_dir, include_main=False):
         git_dir: Path to git directory
         include_main: If True, include the main worktree in results
     """
+    # Use existing parsers to avoid duplicating parsing logic
+    entries = parse_worktree_porcelain(git_dir, include_main=include_main)
+    if entries is None:
+        entries = parse_worktree_legacy(git_dir, include_main=include_main)
+
     git_worktrees = {}
-    try:
-        result = run_git_quiet(["worktree", "list"], git_dir)
+    for entry in entries:
+        branch = entry.get("branch")
+        path = entry.get("path")
+        # Skip detached HEAD worktrees
+        if branch and path and not entry.get("detached"):
+            git_worktrees[branch] = path
 
-        lines = result.stdout.splitlines()
-        for i, line in enumerate(lines):
-            parts = line.split()
-            if len(parts) >= 3:
-                path = parts[0]
-                branch_info = parts[2]
-                # Extract branch name from [branch] format
-                branch = branch_info.strip("[]")
-
-                # Skip the first entry - it's the main working tree
-                if i == 0 and not include_main:
-                    continue
-
-                # Skip detached HEAD worktrees
-                if branch != "(detached)" and not branch.startswith("(HEAD"):
-                    git_worktrees[branch] = path
-
-        return git_worktrees
-    except subprocess.CalledProcessError as e:
-        print(f"Error listing git worktrees: {e}", file=sys.stderr)
-        sys.exit(1)
+    return git_worktrees
 
 
 def get_directory_worktrees(git_dir):

--- a/gwtlib/paths.py
+++ b/gwtlib/paths.py
@@ -60,12 +60,3 @@ def rel_display_path(path: str, git_dir: str, force_absolute: bool) -> str:
     if base and os.path.abspath(path).startswith(os.path.abspath(base) + os.sep):
         return cast(str, os.path.relpath(path, os.path.dirname(base)))
     return os.path.abspath(path)
-
-
-def _normalize_repo_path(p: str) -> str:
-    """Auto-append .git for non-bare repositories when given a repo root directory."""
-    if os.path.isdir(p):
-        dot_git = os.path.join(p, ".git")
-        if os.path.isdir(dot_git):
-            return dot_git
-    return p

--- a/gwtlib/resolution.py
+++ b/gwtlib/resolution.py
@@ -8,11 +8,26 @@ from gwtlib.git_ops import run_git_simple
 
 
 def _normalize_repo_path(p: str) -> str:
-    """Auto-append .git for non-bare repositories when given a repo root directory."""
+    """Auto-append .git for non-bare repositories when given a repo root directory.
+
+    Also handles worktrees and submodules where .git is a file containing a gitdir pointer.
+    """
     if os.path.isdir(p):
         dot_git = os.path.join(p, ".git")
         if os.path.isdir(dot_git):
             return dot_git
+        if os.path.isfile(dot_git):
+            # Worktree or submodule: .git is a file with "gitdir: <path>"
+            try:
+                with open(dot_git, "r", encoding="utf-8") as fh:
+                    line = fh.readline().strip()
+                if line.startswith("gitdir:"):
+                    gitdir = line[len("gitdir:") :].strip()
+                    if not os.path.isabs(gitdir):
+                        gitdir = os.path.abspath(os.path.join(p, gitdir))
+                    return gitdir
+            except OSError:
+                pass
     return p
 
 

--- a/gwtlib/resolution.py
+++ b/gwtlib/resolution.py
@@ -5,7 +5,15 @@ from typing import Optional
 
 from gwtlib.config import HAS_TOML, load_config
 from gwtlib.git_ops import run_git_simple
-from gwtlib.paths import _normalize_repo_path
+
+
+def _normalize_repo_path(p: str) -> str:
+    """Auto-append .git for non-bare repositories when given a repo root directory."""
+    if os.path.isdir(p):
+        dot_git = os.path.join(p, ".git")
+        if os.path.isdir(dot_git):
+            return dot_git
+    return p
 
 
 def auto_detect_git_dir(cwd: Optional[str] = None) -> Optional[str]:

--- a/gwtlib/ui.py
+++ b/gwtlib/ui.py
@@ -1,0 +1,23 @@
+# gwtlib/ui.py
+"""User interaction utilities."""
+
+import sys
+
+
+def prompt_yes_no(prompt: str, default: bool = False) -> bool:
+    """Prompt the user for a yes/no confirmation.
+
+    Args:
+        prompt: The prompt message (without the y/N suffix)
+        default: The default value if user just presses Enter
+
+    Returns:
+        True for yes, False for no
+    """
+    suffix = "(Y/n)" if default else "(y/N)"
+    print(f"{prompt} {suffix}: ", end="", file=sys.stderr)
+    sys.stderr.flush()
+    response = input().strip().lower()
+    if not response:
+        return default
+    return response in ("y", "yes")

--- a/gwtlib/ui.py
+++ b/gwtlib/ui.py
@@ -17,7 +17,11 @@ def prompt_yes_no(prompt: str, default: bool = False) -> bool:
     suffix = "(Y/n)" if default else "(y/N)"
     print(f"{prompt} {suffix}: ", end="", file=sys.stderr)
     sys.stderr.flush()
-    response = input().strip().lower()
+    try:
+        response = input().strip().lower()
+    except EOFError:
+        # Non-interactive context (e.g., piped input, CI)
+        return default
     if not response:
         return default
     return response in ("y", "yes")

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -325,7 +325,7 @@ def remove_worktree(branch_name: str, git_dir: str) -> None:
         pr_state = None
         pr_is_merged = False
         if has_remote:
-            pr_info = get_pr_state(branch_name)
+            pr_info = get_pr_state(branch_name, cwd=worktree_path)
             if pr_info:
                 pr_state, pr_is_merged = pr_info
 

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -219,8 +219,6 @@ def _is_worktree_locked(worktree_path: str, git_dir: str) -> bool:
 class PreflightError(Exception):
     """Raised when pre-flight checks fail."""
 
-    pass
-
 
 def _preflight_check_removal(
     branch_name: str,
@@ -442,7 +440,9 @@ def _remove_all(
                     )
                     deleted_remote = True
                 else:
-                    raise RuntimeError(f"Failed to delete remote branch: {error_msg}")
+                    raise RuntimeError(
+                        f"Failed to delete remote branch: {error_msg}"
+                    ) from None
 
         # Step 2: Delete local branch (skip if doesn't exist)
         if branch_exists_locally(branch_name, git_dir):
@@ -452,7 +452,7 @@ def _remove_all(
                 deleted_local = True
             except subprocess.CalledProcessError as e:
                 error_msg = e.stderr.strip() if e.stderr else str(e)
-                raise RuntimeError(f"Failed to delete local branch: {error_msg}")
+                raise RuntimeError(f"Failed to delete local branch: {error_msg}") from e
         else:
             print(f"Local branch '{branch_name}' already deleted", file=sys.stderr)
             deleted_local = True

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -1,4 +1,12 @@
 # gwtlib/worktrees.py
+#
+# TODO: Refactor _remove_all, _remove_local_only, _remove_with_prompts to reduce duplication.
+# Extract common operations into helpers:
+#   - _do_preflight_checks() - dirty/locked checks with prompts
+#   - _do_remove_worktree() - worktree removal + error handling
+#   - _do_delete_local_branch() - branch deletion + error handling
+#   - _do_delete_remote_branch() - remote deletion + error handling (partially exists)
+
 import os
 import subprocess
 import sys
@@ -444,7 +452,16 @@ def _remove_all(
                         f"Failed to delete remote branch: {error_msg}"
                     ) from None
 
-        # Step 2: Delete local branch (skip if doesn't exist)
+        # Step 2: Remove worktree (must happen before branch deletion)
+        # Git refuses to delete a branch that's checked out in a worktree
+        if safe_dir:
+            os.chdir(safe_dir)
+
+        run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
+        print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+        removed_worktree = True
+
+        # Step 3: Delete local branch (now safe since worktree is removed)
         if branch_exists_locally(branch_name, git_dir):
             try:
                 run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
@@ -456,14 +473,6 @@ def _remove_all(
         else:
             print(f"Local branch '{branch_name}' already deleted", file=sys.stderr)
             deleted_local = True
-
-        # Step 3: Remove worktree (need to cd out first if we're in it)
-        if safe_dir:
-            os.chdir(safe_dir)
-
-        run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
-        print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
-        removed_worktree = True
 
     except RuntimeError as e:
         # Report what succeeded and what failed
@@ -495,7 +504,7 @@ def _remove_local_only(
 ) -> None:
     """Remove worktree and prompt for local branch deletion (original behavior).
 
-    Order: local branch -> worktree (for best-effort atomicity).
+    Order: worktree -> local branch (git refuses to delete a branch checked out in a worktree).
     """
     # Check for dirty worktree upfront
     if is_worktree_dirty(worktree_path):
@@ -513,20 +522,10 @@ def _remove_local_only(
             file=sys.stderr,
         )
 
-    # Step 1: Local branch (prompted)
+    # Ask about branch deletion upfront (before removing worktree)
     delete_local = prompt_yes_no(f"Delete local branch '{branch_name}'?")
-    if delete_local:
-        try:
-            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
-            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr.strip() if e.stderr else str(e)
-            print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)
-            if not prompt_yes_no("Continue with worktree removal?"):
-                print("Aborted.", file=sys.stderr)
-                return
 
-    # Step 2: Remove worktree
+    # Step 1: Remove worktree first (required before branch can be deleted)
     if safe_dir:
         os.chdir(safe_dir)
     try:
@@ -535,6 +534,19 @@ def _remove_local_only(
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.strip() if e.stderr else str(e)
         print(f"Failed to remove worktree: {error_msg}", file=sys.stderr)
+        # Output cd command if needed even on failure
+        if safe_dir:
+            print(f"cd {safe_dir}")
+        return
+
+    # Step 2: Delete local branch (now safe since worktree is removed)
+    if delete_local:
+        try:
+            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.strip() if e.stderr else str(e)
+            print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)
 
     # Output cd command if needed
     if safe_dir:
@@ -551,7 +563,7 @@ def _remove_with_prompts(
     """Remove with explicit prompts for each component.
 
     For cautious removal (when PR is not merged), we ask about each component.
-    Order: remote -> local -> worktree (for best-effort atomicity).
+    Order: remote -> worktree -> local (git refuses to delete a branch checked out in a worktree).
     """
     # Show what will be prompted
     print("The following may be removed:", file=sys.stderr)
@@ -584,43 +596,38 @@ def _remove_with_prompts(
             file=sys.stderr,
         )
 
-    # Step 1: Remote branch (prompted)
+    # Gather user choices upfront (before making any changes)
+    delete_remote = False
     if remote_name:
-        if prompt_yes_no(f"Delete remote branch '{remote_name}/{branch_name}'?"):
-            # Pre-check before committing
-            can_delete, error_msg = can_delete_remote_branch(
-                branch_name, remote_name, git_dir
-            )
-            if not can_delete:
-                print(f"Cannot delete remote branch: {error_msg}", file=sys.stderr)
-                if not prompt_yes_no("Continue with local cleanup?"):
-                    print("Aborted.", file=sys.stderr)
-                    return
-            else:
-                success, error_msg = delete_remote_branch(
-                    branch_name, remote_name, git_dir
+        delete_remote = prompt_yes_no(
+            f"Delete remote branch '{remote_name}/{branch_name}'?"
+        )
+    delete_local = prompt_yes_no(f"Delete local branch '{branch_name}'?")
+    remove_worktree = prompt_yes_no(f"Remove worktree for '{branch_name}'?")
+
+    # Step 1: Remote branch
+    if delete_remote and remote_name:
+        # Pre-check before committing
+        can_delete, error_msg = can_delete_remote_branch(
+            branch_name, remote_name, git_dir
+        )
+        if not can_delete:
+            print(f"Cannot delete remote branch: {error_msg}", file=sys.stderr)
+            if not prompt_yes_no("Continue with local cleanup?"):
+                print("Aborted.", file=sys.stderr)
+                return
+        else:
+            success, error_msg = delete_remote_branch(branch_name, remote_name, git_dir)
+            if success:
+                print(
+                    f"Deleted remote branch '{remote_name}/{branch_name}'",
+                    file=sys.stderr,
                 )
-                if success:
-                    print(
-                        f"Deleted remote branch '{remote_name}/{branch_name}'",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(
-                        f"Failed to delete remote branch: {error_msg}", file=sys.stderr
-                    )
+            else:
+                print(f"Failed to delete remote branch: {error_msg}", file=sys.stderr)
 
-    # Step 2: Local branch (prompted)
-    if prompt_yes_no(f"Delete local branch '{branch_name}'?"):
-        try:
-            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
-            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr.strip() if e.stderr else str(e)
-            print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)
-
-    # Step 3: Worktree (prompted)
-    if prompt_yes_no(f"Remove worktree for '{branch_name}'?"):
+    # Step 2: Worktree (must happen before local branch deletion)
+    if remove_worktree:
         if safe_dir:
             os.chdir(safe_dir)
         try:
@@ -631,6 +638,31 @@ def _remove_with_prompts(
         except subprocess.CalledProcessError as e:
             error_msg = e.stderr.strip() if e.stderr else str(e)
             print(f"Failed to remove worktree: {error_msg}", file=sys.stderr)
+            # Can't delete branch if worktree removal failed
+            if delete_local:
+                print(
+                    "Skipping local branch deletion (worktree still exists)",
+                    file=sys.stderr,
+                )
+            if safe_dir:
+                print(f"cd {safe_dir}")
+            return
+
+    # Step 3: Local branch (now safe since worktree is removed)
+    if delete_local:
+        if not remove_worktree:
+            # User declined worktree removal, so we can't delete the branch
+            print(
+                "Skipping local branch deletion (worktree still exists)",
+                file=sys.stderr,
+            )
+        else:
+            try:
+                run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+                print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+            except subprocess.CalledProcessError as e:
+                error_msg = e.stderr.strip() if e.stderr else str(e)
+                print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)
 
     # Output cd command if needed
     if safe_dir:

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -575,7 +575,6 @@ def _remove_with_prompts(
         )
 
     # Step 1: Remote branch (prompted)
-    delete_remote = False
     if remote_name:
         if prompt_yes_no(f"Delete remote branch '{remote_name}/{branch_name}'?"):
             # Pre-check before committing
@@ -596,19 +595,16 @@ def _remove_with_prompts(
                         f"Deleted remote branch '{remote_name}/{branch_name}'",
                         file=sys.stderr,
                     )
-                    delete_remote = True
                 else:
                     print(
                         f"Failed to delete remote branch: {error_msg}", file=sys.stderr
                     )
 
     # Step 2: Local branch (prompted)
-    delete_local = False
     if prompt_yes_no(f"Delete local branch '{branch_name}'?"):
         try:
             run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
             print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
-            delete_local = True
         except subprocess.CalledProcessError as e:
             error_msg = e.stderr.strip() if e.stderr else str(e)
             print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -7,10 +7,15 @@ from typing import Optional
 
 from gwtlib.branches import (
     branch_exists_locally,
+    delete_remote_branch,
     find_remote_branch,
     get_main_branch_name,
+    get_pr_state,
+    get_remote_tracking_branch,
+    remote_branch_exists,
 )
 from gwtlib.config import get_repo_config
+from gwtlib.display import prompt_yes_no
 from gwtlib.git_ops import run_git_command
 from gwtlib.parsing import get_worktree_list
 from gwtlib.paths import get_main_worktree_path, get_worktree_base
@@ -165,7 +170,43 @@ def switch_branch(branch_name, git_dir, create=False, force_create=False, guess=
     sys.exit(1)
 
 
+def _get_safe_dir_if_needed(worktree_path: str, git_dir: str) -> Optional[str]:
+    """Check if we're in the worktree being removed, return safe dir if so.
+
+    Returns:
+        The safe directory to change to, or None if not needed.
+    """
+    current_dir = os.getcwd()
+    worktree_abs = os.path.abspath(worktree_path)
+    current_abs = os.path.abspath(current_dir)
+
+    if current_abs.startswith(worktree_abs + os.sep) or current_abs == worktree_abs:
+        git_dir_path = Path(git_dir).resolve()
+
+        if git_dir_path.name == ".git" and git_dir_path.is_dir():
+            # Non-bare repo: git_dir is /path/to/repo/.git
+            safe_dir = str(git_dir_path.parent)
+        else:
+            # Bare repo: git_dir is /path/to/repo.git
+            safe_dir = os.path.dirname(get_worktree_base(git_dir))
+
+        print(
+            f"You're in the worktree being removed. Will change to {safe_dir} after removal.",
+            file=sys.stderr,
+        )
+        return safe_dir
+    return None
+
+
 def remove_worktree(branch_name: str, git_dir: str) -> None:
+    """Remove a worktree and optionally its local and remote branches.
+
+    The behavior depends on the branch state:
+
+    1. PR is merged: Automatically removes worktree, local branch, and remote branch.
+    2. Branch not synced to remote: Removes worktree, prompts for local branch deletion.
+    3. Branch synced but PR not merged: Shows warning, prompts for each deletion.
+    """
     try:
         # Find the worktree path using our shared function
         worktrees = get_worktree_list(git_dir)
@@ -182,58 +223,185 @@ def remove_worktree(branch_name: str, git_dir: str) -> None:
                 f"Error: Worktree for branch '{branch_name}' not found", file=sys.stderr
             )
             sys.exit(1)
-        # Narrow type for static checkers and add runtime safety
         assert worktree_path is not None
 
-        # Check if we're currently in the worktree being removed
-        current_dir = os.getcwd()
-        worktree_abs = os.path.abspath(worktree_path)
-        current_abs = os.path.abspath(current_dir)
+        # Check if we need to change directory after removal
+        safe_dir = _get_safe_dir_if_needed(worktree_path, git_dir)
 
-        need_cd = False
-        if current_abs.startswith(worktree_abs + os.sep) or current_abs == worktree_abs:
-            need_cd = True
-            # Determine the safe directory based on repo type
-            git_dir_path = Path(git_dir).resolve()
+        # Determine branch state
+        remote_ref = get_remote_tracking_branch(branch_name, git_dir)
+        has_remote = remote_ref is not None and remote_branch_exists(
+            remote_ref, git_dir
+        )
 
-            if git_dir_path.name == ".git" and git_dir_path.is_dir():
-                # Non-bare repo: git_dir is /path/to/repo/.git
-                # Safe dir should be the repo itself: /path/to/repo
-                safe_dir = str(git_dir_path.parent)
-            else:
-                # Bare repo: git_dir is /path/to/repo.git
-                # Safe dir should be parent of .gwt: /path/to
-                safe_dir = os.path.dirname(get_worktree_base(git_dir))
+        # Parse remote info for deletion
+        remote_name: Optional[str] = None
+        if has_remote and remote_ref:
+            # remote_ref is like 'origin/branch-name'
+            parts = remote_ref.split("/", 1)
+            if len(parts) == 2:
+                remote_name = parts[0]
 
+        # Check PR state if branch has a remote
+        pr_state = None
+        pr_is_merged = False
+        if has_remote:
+            pr_info = get_pr_state(branch_name)
+            if pr_info:
+                pr_state, pr_is_merged = pr_info
+
+        # Determine removal strategy based on state
+        if pr_is_merged:
+            # Case 1: PR is merged - clean up everything automatically
             print(
-                f"You're in the worktree being removed. Will change to {safe_dir} after removal.",
+                f"PR for '{branch_name}' has been merged. Cleaning up...",
                 file=sys.stderr,
             )
+            _remove_all(
+                branch_name,
+                git_dir,
+                worktree_path,
+                safe_dir,
+                remote_name,
+            )
+        elif not has_remote:
+            # Case 2: Branch not synced to remote - current behavior
+            _remove_local_only(branch_name, git_dir, worktree_path, safe_dir)
+        else:
+            # Case 3: Branch synced to remote but PR not merged (or no PR)
+            if pr_state == "OPEN":
+                print(
+                    f"\nWARNING: PR for '{branch_name}' is still OPEN!",
+                    file=sys.stderr,
+                )
+            elif pr_state == "CLOSED":
+                print(
+                    f"\nWARNING: PR for '{branch_name}' was CLOSED (not merged).",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"\nWARNING: Branch '{branch_name}' is synced to remote.",
+                    file=sys.stderr,
+                )
+            print(
+                "Others may have access to this branch. Proceeding with caution.\n",
+                file=sys.stderr,
+            )
+            _remove_with_prompts(
+                branch_name,
+                git_dir,
+                worktree_path,
+                safe_dir,
+                remote_name,
+            )
 
-        # Remove the worktree (don't capture output as it might prompt the user)
-        run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
-
-        # Then remove the branch if the user confirms
-        # Print to stderr and flush to ensure prompt is visible immediately
-        print(
-            f"Do you also want to delete the branch '{branch_name}'? (y/N): ",
-            end="",
-            file=sys.stderr,
-        )
-        sys.stderr.flush()
-        confirm = input()
-        if confirm.lower() == "y":
-            # Change to safe directory first if needed, before trying to delete branch
-            if need_cd:
-                os.chdir(safe_dir)
-            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
-            print(f"Branch '{branch_name}' has been deleted")
-
-        print(f"Worktree for '{branch_name}' has been removed")
-
-        # Output the cd command for the shell to execute if we were in the removed worktree
-        if need_cd:
-            print(f"cd {safe_dir}")
     except subprocess.CalledProcessError as e:
         print(f"Error removing worktree: {e}", file=sys.stderr)
         sys.exit(1)
+
+
+def _remove_all(
+    branch_name: str,
+    git_dir: str,
+    worktree_path: str,
+    safe_dir: Optional[str],
+    remote_name: Optional[str],
+) -> None:
+    """Remove worktree, local branch, and remote branch without prompting."""
+    # Remove worktree
+    run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
+    print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+
+    # Change to safe directory if needed before branch operations
+    if safe_dir:
+        os.chdir(safe_dir)
+
+    # Remove local branch
+    try:
+        run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+        print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+    except subprocess.CalledProcessError:
+        print(f"Note: Could not delete local branch '{branch_name}'", file=sys.stderr)
+
+    # Remove remote branch
+    if remote_name:
+        if delete_remote_branch(branch_name, remote_name, git_dir):
+            print(
+                f"Deleted remote branch '{remote_name}/{branch_name}'", file=sys.stderr
+            )
+        else:
+            print(
+                f"Note: Could not delete remote branch (may already be deleted)",
+                file=sys.stderr,
+            )
+
+    # Output cd command if needed
+    if safe_dir:
+        print(f"cd {safe_dir}")
+
+
+def _remove_local_only(
+    branch_name: str,
+    git_dir: str,
+    worktree_path: str,
+    safe_dir: Optional[str],
+) -> None:
+    """Remove worktree and prompt for local branch deletion (original behavior)."""
+    # Remove worktree
+    run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
+    print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+
+    # Prompt for local branch deletion
+    if prompt_yes_no(f"Delete local branch '{branch_name}'?"):
+        if safe_dir:
+            os.chdir(safe_dir)
+        run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+        print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+
+    # Output cd command if needed
+    if safe_dir:
+        print(f"cd {safe_dir}")
+
+
+def _remove_with_prompts(
+    branch_name: str,
+    git_dir: str,
+    worktree_path: str,
+    safe_dir: Optional[str],
+    remote_name: Optional[str],
+) -> None:
+    """Remove with explicit prompts for each component."""
+    # Prompt for worktree removal
+    if not prompt_yes_no(f"Remove worktree for '{branch_name}'?"):
+        print("Aborted.", file=sys.stderr)
+        return
+
+    run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
+    print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+
+    # Prompt for local branch deletion
+    delete_local = prompt_yes_no(f"Delete local branch '{branch_name}'?")
+    if delete_local:
+        if safe_dir:
+            os.chdir(safe_dir)
+        try:
+            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+        except subprocess.CalledProcessError:
+            print(f"Note: Could not delete local branch", file=sys.stderr)
+
+    # Prompt for remote branch deletion
+    if remote_name:
+        if prompt_yes_no(f"Delete remote branch '{remote_name}/{branch_name}'?"):
+            if delete_remote_branch(branch_name, remote_name, git_dir):
+                print(
+                    f"Deleted remote branch '{remote_name}/{branch_name}'",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"Note: Could not delete remote branch", file=sys.stderr)
+
+    # Output cd command if needed
+    if safe_dir:
+        print(f"cd {safe_dir}")

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -17,7 +17,11 @@ from gwtlib.paths import get_main_worktree_path, get_worktree_base
 
 
 def create_worktree_for_branch(branch_name, git_dir, worktree_path):
-    """Create a worktree for an existing local branch."""
+    """Create a worktree for an existing local branch.
+
+    This creates the git worktree and then runs any post-create commands
+    configured for this repository (e.g., npm install, pip install).
+    """
     try:
         run_git_command(["worktree", "add", worktree_path, branch_name], git_dir)
         print(f"Created worktree at {worktree_path}", file=sys.stderr)
@@ -29,7 +33,11 @@ def create_worktree_for_branch(branch_name, git_dir, worktree_path):
 
 
 def create_tracking_worktree(branch_name, git_dir, remote_ref, worktree_path):
-    """Create a worktree that tracks a remote branch."""
+    """Create a worktree that tracks a remote branch.
+
+    This creates a local branch tracking the remote, creates the git worktree,
+    and then runs any post-create commands configured for this repository.
+    """
     try:
         # Create local branch tracking the remote
         run_git_command(
@@ -121,8 +129,13 @@ def switch_branch(branch_name, git_dir, create=False, force_create=False, guess=
             print("Use -C to force create", file=sys.stderr)
             sys.exit(1)
 
-    # Check if local branch exists
+    # Check if local branch exists - create worktree for it
+    # (this also runs any configured post-create commands)
     if branch_exists_locally(branch_name, git_dir):
+        print(
+            f"Branch '{branch_name}' exists locally but has no worktree. Creating worktree...",
+            file=sys.stderr,
+        )
         create_worktree_for_branch(branch_name, git_dir, worktree_path)
         return
 

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -232,27 +232,29 @@ def _preflight_check_removal(
     worktree_path: str,
     remote_name: Optional[str],
     check_remote: bool = True,
-) -> None:
-    """Run pre-flight checks before removal. Raises PreflightError on failure.
+) -> list:
+    """Run pre-flight checks before removal.
 
     Checks:
-    - Worktree is not dirty (uncommitted changes)
-    - Worktree is not locked
-    - Local branch exists
-    - Remote branch can be deleted (dry-run) if applicable
+    - Worktree is not locked (hard failure)
+    - Remote branch can be deleted (dry-run) if applicable (hard failure)
+
+    Returns list of warnings (e.g., dirty worktree, missing local branch).
+    Raises PreflightError for hard failures that should block removal.
     """
     errors = []
+    warnings = []
 
-    # Check worktree state
+    # Check worktree state - dirty is a warning, locked is an error
     if _is_worktree_dirty(worktree_path):
-        errors.append(f"Worktree has uncommitted changes: {worktree_path}")
+        warnings.append(f"Worktree has uncommitted changes: {worktree_path}")
 
     if _is_worktree_locked(worktree_path, git_dir):
         errors.append(f"Worktree is locked: {worktree_path}")
 
-    # Check local branch exists
+    # Missing local branch is OK - just skip that step
     if not branch_exists_locally(branch_name, git_dir):
-        errors.append(f"Local branch '{branch_name}' does not exist")
+        warnings.append(f"Local branch '{branch_name}' does not exist (will skip)")
 
     # Check remote deletion is possible (dry-run)
     if check_remote and remote_name:
@@ -266,6 +268,8 @@ def _preflight_check_removal(
 
     if errors:
         raise PreflightError("\n".join(errors))
+
+    return warnings
 
 
 def remove_worktree(branch_name: str, git_dir: str) -> None:
@@ -391,15 +395,23 @@ def _remove_all(
     """
     # Pre-flight checks - verify everything before deleting anything
     try:
-        _preflight_check_removal(
+        warnings = _preflight_check_removal(
             branch_name, git_dir, worktree_path, remote_name, check_remote=True
         )
     except PreflightError as e:
-        print(f"Pre-flight check failed:\n{e}", file=sys.stderr)
+        print(f"Cannot proceed:\n{e}", file=sys.stderr)
         print(
             "\nNo changes were made. Fix the issues above and retry.", file=sys.stderr
         )
         sys.exit(1)
+
+    # Show warnings and confirm if needed
+    if warnings:
+        for warning in warnings:
+            print(f"Warning: {warning}", file=sys.stderr)
+        if not prompt_yes_no("Continue anyway?"):
+            print("Aborted. No changes were made.", file=sys.stderr)
+            sys.exit(0)
 
     if safe_dir:
         print(
@@ -433,14 +445,18 @@ def _remove_all(
                 else:
                     raise RuntimeError(f"Failed to delete remote branch: {error_msg}")
 
-        # Step 2: Delete local branch
-        try:
-            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
-            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+        # Step 2: Delete local branch (skip if doesn't exist)
+        if branch_exists_locally(branch_name, git_dir):
+            try:
+                run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+                print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+                deleted_local = True
+            except subprocess.CalledProcessError as e:
+                error_msg = e.stderr.strip() if e.stderr else str(e)
+                raise RuntimeError(f"Failed to delete local branch: {error_msg}")
+        else:
+            print(f"Local branch '{branch_name}' already deleted", file=sys.stderr)
             deleted_local = True
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr.strip() if e.stderr else str(e)
-            raise RuntimeError(f"Failed to delete local branch: {error_msg}")
 
         # Step 3: Remove worktree (need to cd out first if we're in it)
         if safe_dir:

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from gwtlib.branches import (
     branch_exists_locally,
+    can_delete_remote_branch,
     delete_remote_branch,
     find_remote_branch,
     get_main_branch_name,
@@ -14,6 +15,7 @@ from gwtlib.branches import (
     get_remote_tracking_branch,
     remote_branch_exists,
 )
+from gwtlib.git_ops import run_git_in_worktree
 from gwtlib.config import get_repo_config
 from gwtlib.display import prompt_yes_no
 from gwtlib.git_ops import run_git_command
@@ -190,12 +192,80 @@ def _get_safe_dir_if_needed(worktree_path: str, git_dir: str) -> Optional[str]:
             # Bare repo: git_dir is /path/to/repo.git
             safe_dir = os.path.dirname(get_worktree_base(git_dir))
 
-        print(
-            f"You're in the worktree being removed. Will change to {safe_dir} after removal.",
-            file=sys.stderr,
-        )
         return safe_dir
     return None
+
+
+def _is_worktree_dirty(worktree_path: str) -> bool:
+    """Check if worktree has uncommitted changes."""
+    try:
+        result = run_git_in_worktree(["status", "--porcelain"], worktree_path)
+        return bool(result.stdout.strip())
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _is_worktree_locked(worktree_path: str, git_dir: str) -> bool:
+    """Check if worktree is locked."""
+    try:
+        from gwtlib.parsing import parse_worktree_porcelain
+
+        entries = parse_worktree_porcelain(git_dir, include_main=False)
+        if entries:
+            for entry in entries:
+                if entry.get("path") == worktree_path:
+                    return entry.get("locked", False)
+    except Exception:
+        pass
+    return False
+
+
+class PreflightError(Exception):
+    """Raised when pre-flight checks fail."""
+
+    pass
+
+
+def _preflight_check_removal(
+    branch_name: str,
+    git_dir: str,
+    worktree_path: str,
+    remote_name: Optional[str],
+    check_remote: bool = True,
+) -> None:
+    """Run pre-flight checks before removal. Raises PreflightError on failure.
+
+    Checks:
+    - Worktree is not dirty (uncommitted changes)
+    - Worktree is not locked
+    - Local branch exists
+    - Remote branch can be deleted (dry-run) if applicable
+    """
+    errors = []
+
+    # Check worktree state
+    if _is_worktree_dirty(worktree_path):
+        errors.append(f"Worktree has uncommitted changes: {worktree_path}")
+
+    if _is_worktree_locked(worktree_path, git_dir):
+        errors.append(f"Worktree is locked: {worktree_path}")
+
+    # Check local branch exists
+    if not branch_exists_locally(branch_name, git_dir):
+        errors.append(f"Local branch '{branch_name}' does not exist")
+
+    # Check remote deletion is possible (dry-run)
+    if check_remote and remote_name:
+        can_delete, error_msg = can_delete_remote_branch(
+            branch_name, remote_name, git_dir
+        )
+        if not can_delete:
+            errors.append(
+                f"Cannot delete remote branch '{remote_name}/{branch_name}': {error_msg}"
+            )
+
+    if errors:
+        raise PreflightError("\n".join(errors))
 
 
 def remove_worktree(branch_name: str, git_dir: str) -> None:
@@ -308,33 +378,94 @@ def _remove_all(
     safe_dir: Optional[str],
     remote_name: Optional[str],
 ) -> None:
-    """Remove worktree, local branch, and remote branch without prompting."""
-    # Remove worktree
-    run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
-    print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+    """Remove worktree, local branch, and remote branch without prompting.
 
-    # Change to safe directory if needed before branch operations
-    if safe_dir:
-        os.chdir(safe_dir)
+    Operations are ordered for best-effort atomicity:
+    1. Pre-flight checks (verify everything can be deleted)
+    2. Delete remote branch (most likely to fail, network operation)
+    3. Delete local branch
+    4. Remove worktree (least important, local cleanup)
 
-    # Remove local branch
+    This ordering means if any step fails, subsequent steps haven't happened yet,
+    and the user can fix the issue and retry.
+    """
+    # Pre-flight checks - verify everything before deleting anything
     try:
-        run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
-        print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
-    except subprocess.CalledProcessError:
-        print(f"Note: Could not delete local branch '{branch_name}'", file=sys.stderr)
+        _preflight_check_removal(
+            branch_name, git_dir, worktree_path, remote_name, check_remote=True
+        )
+    except PreflightError as e:
+        print(f"Pre-flight check failed:\n{e}", file=sys.stderr)
+        print(
+            "\nNo changes were made. Fix the issues above and retry.", file=sys.stderr
+        )
+        sys.exit(1)
 
-    # Remove remote branch
-    if remote_name:
-        if delete_remote_branch(branch_name, remote_name, git_dir):
-            print(
-                f"Deleted remote branch '{remote_name}/{branch_name}'", file=sys.stderr
-            )
-        else:
-            print(
-                f"Note: Could not delete remote branch (may already be deleted)",
-                file=sys.stderr,
-            )
+    if safe_dir:
+        print(
+            f"You're in the worktree being removed. Will change to {safe_dir} after removal.",
+            file=sys.stderr,
+        )
+
+    # Track what we've done for error reporting
+    deleted_remote = False
+    deleted_local = False
+    removed_worktree = False
+
+    try:
+        # Step 1: Delete remote branch first (network operation, most likely to fail)
+        if remote_name:
+            success, error_msg = delete_remote_branch(branch_name, remote_name, git_dir)
+            if success:
+                print(
+                    f"Deleted remote branch '{remote_name}/{branch_name}'",
+                    file=sys.stderr,
+                )
+                deleted_remote = True
+            else:
+                # Check if it's already deleted (not a real error)
+                if "remote ref does not exist" in error_msg.lower():
+                    print(
+                        f"Remote branch '{remote_name}/{branch_name}' already deleted",
+                        file=sys.stderr,
+                    )
+                    deleted_remote = True
+                else:
+                    raise RuntimeError(f"Failed to delete remote branch: {error_msg}")
+
+        # Step 2: Delete local branch
+        try:
+            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+            deleted_local = True
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.strip() if e.stderr else str(e)
+            raise RuntimeError(f"Failed to delete local branch: {error_msg}")
+
+        # Step 3: Remove worktree (need to cd out first if we're in it)
+        if safe_dir:
+            os.chdir(safe_dir)
+
+        run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
+        print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+        removed_worktree = True
+
+    except RuntimeError as e:
+        # Report what succeeded and what failed
+        print(f"\nError during removal: {e}", file=sys.stderr)
+        print("\nStatus:", file=sys.stderr)
+        if remote_name:
+            status = "deleted" if deleted_remote else "NOT deleted"
+            print(f"  Remote branch: {status}", file=sys.stderr)
+        print(
+            f"  Local branch: {'deleted' if deleted_local else 'NOT deleted'}",
+            file=sys.stderr,
+        )
+        print(
+            f"  Worktree: {'removed' if removed_worktree else 'NOT removed'}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Output cd command if needed
     if safe_dir:
@@ -347,17 +478,48 @@ def _remove_local_only(
     worktree_path: str,
     safe_dir: Optional[str],
 ) -> None:
-    """Remove worktree and prompt for local branch deletion (original behavior)."""
-    # Remove worktree
-    run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
-    print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+    """Remove worktree and prompt for local branch deletion (original behavior).
 
-    # Prompt for local branch deletion
-    if prompt_yes_no(f"Delete local branch '{branch_name}'?"):
-        if safe_dir:
-            os.chdir(safe_dir)
-        run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
-        print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+    Order: local branch -> worktree (for best-effort atomicity).
+    """
+    # Check for dirty worktree upfront
+    if _is_worktree_dirty(worktree_path):
+        print(
+            f"WARNING: Worktree has uncommitted changes: {worktree_path}",
+            file=sys.stderr,
+        )
+        if not prompt_yes_no("Continue anyway?"):
+            print("Aborted.", file=sys.stderr)
+            return
+
+    if safe_dir:
+        print(
+            f"Note: You're in this worktree. Will change to {safe_dir} after removal.",
+            file=sys.stderr,
+        )
+
+    # Step 1: Local branch (prompted)
+    delete_local = prompt_yes_no(f"Delete local branch '{branch_name}'?")
+    if delete_local:
+        try:
+            run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
+            print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.strip() if e.stderr else str(e)
+            print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)
+            if not prompt_yes_no("Continue with worktree removal?"):
+                print("Aborted.", file=sys.stderr)
+                return
+
+    # Step 2: Remove worktree
+    if safe_dir:
+        os.chdir(safe_dir)
+    try:
+        run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
+        print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+    except subprocess.CalledProcessError as e:
+        error_msg = e.stderr.strip() if e.stderr else str(e)
+        print(f"Failed to remove worktree: {error_msg}", file=sys.stderr)
 
     # Output cd command if needed
     if safe_dir:
@@ -371,36 +533,93 @@ def _remove_with_prompts(
     safe_dir: Optional[str],
     remote_name: Optional[str],
 ) -> None:
-    """Remove with explicit prompts for each component."""
-    # Prompt for worktree removal
-    if not prompt_yes_no(f"Remove worktree for '{branch_name}'?"):
-        print("Aborted.", file=sys.stderr)
-        return
+    """Remove with explicit prompts for each component.
 
-    run_git_command(["worktree", "remove", worktree_path], git_dir, capture=False)
-    print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+    For cautious removal (when PR is not merged), we ask about each component.
+    Order: remote -> local -> worktree (for best-effort atomicity).
+    """
+    # Show what will be prompted
+    print("The following may be removed:", file=sys.stderr)
+    if remote_name:
+        print(f"  - Remote branch: {remote_name}/{branch_name}", file=sys.stderr)
+    print(f"  - Local branch: {branch_name}", file=sys.stderr)
+    print(f"  - Worktree: {worktree_path}", file=sys.stderr)
+    print("", file=sys.stderr)
 
-    # Prompt for local branch deletion
-    delete_local = prompt_yes_no(f"Delete local branch '{branch_name}'?")
-    if delete_local:
-        if safe_dir:
-            os.chdir(safe_dir)
+    # Check for dirty worktree upfront
+    if _is_worktree_dirty(worktree_path):
+        print(
+            f"WARNING: Worktree has uncommitted changes: {worktree_path}",
+            file=sys.stderr,
+        )
+        if not prompt_yes_no("Continue anyway?"):
+            print("Aborted.", file=sys.stderr)
+            return
+
+    # Check for locked worktree
+    if _is_worktree_locked(worktree_path, git_dir):
+        print(f"WARNING: Worktree is locked: {worktree_path}", file=sys.stderr)
+        if not prompt_yes_no("Continue anyway?"):
+            print("Aborted.", file=sys.stderr)
+            return
+
+    if safe_dir:
+        print(
+            f"Note: You're in this worktree. Will change to {safe_dir} after removal.",
+            file=sys.stderr,
+        )
+
+    # Step 1: Remote branch (prompted)
+    delete_remote = False
+    if remote_name:
+        if prompt_yes_no(f"Delete remote branch '{remote_name}/{branch_name}'?"):
+            # Pre-check before committing
+            can_delete, error_msg = can_delete_remote_branch(
+                branch_name, remote_name, git_dir
+            )
+            if not can_delete:
+                print(f"Cannot delete remote branch: {error_msg}", file=sys.stderr)
+                if not prompt_yes_no("Continue with local cleanup?"):
+                    print("Aborted.", file=sys.stderr)
+                    return
+            else:
+                success, error_msg = delete_remote_branch(
+                    branch_name, remote_name, git_dir
+                )
+                if success:
+                    print(
+                        f"Deleted remote branch '{remote_name}/{branch_name}'",
+                        file=sys.stderr,
+                    )
+                    delete_remote = True
+                else:
+                    print(
+                        f"Failed to delete remote branch: {error_msg}", file=sys.stderr
+                    )
+
+    # Step 2: Local branch (prompted)
+    delete_local = False
+    if prompt_yes_no(f"Delete local branch '{branch_name}'?"):
         try:
             run_git_command(["branch", "-D", branch_name], git_dir, capture=False)
             print(f"Deleted local branch '{branch_name}'", file=sys.stderr)
-        except subprocess.CalledProcessError:
-            print(f"Note: Could not delete local branch", file=sys.stderr)
+            delete_local = True
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.strip() if e.stderr else str(e)
+            print(f"Failed to delete local branch: {error_msg}", file=sys.stderr)
 
-    # Prompt for remote branch deletion
-    if remote_name:
-        if prompt_yes_no(f"Delete remote branch '{remote_name}/{branch_name}'?"):
-            if delete_remote_branch(branch_name, remote_name, git_dir):
-                print(
-                    f"Deleted remote branch '{remote_name}/{branch_name}'",
-                    file=sys.stderr,
-                )
-            else:
-                print(f"Note: Could not delete remote branch", file=sys.stderr)
+    # Step 3: Worktree (prompted)
+    if prompt_yes_no(f"Remove worktree for '{branch_name}'?"):
+        if safe_dir:
+            os.chdir(safe_dir)
+        try:
+            run_git_command(
+                ["worktree", "remove", worktree_path], git_dir, capture=False
+            )
+            print(f"Removed worktree for '{branch_name}'", file=sys.stderr)
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.strip() if e.stderr else str(e)
+            print(f"Failed to remove worktree: {error_msg}", file=sys.stderr)
 
     # Output cd command if needed
     if safe_dir:

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -10,17 +10,15 @@ from gwtlib.branches import (
     can_delete_remote_branch,
     delete_remote_branch,
     find_remote_branch,
-    get_main_branch_name,
-    get_pr_state,
     get_remote_tracking_branch,
     remote_branch_exists,
 )
-from gwtlib.git_ops import run_git_in_worktree
 from gwtlib.config import get_repo_config
-from gwtlib.display import prompt_yes_no
-from gwtlib.git_ops import run_git_command
-from gwtlib.parsing import get_worktree_list
+from gwtlib.git_ops import is_worktree_dirty, run_git_command
+from gwtlib.github import get_pr_state
+from gwtlib.parsing import get_main_branch_name, get_worktree_list
 from gwtlib.paths import get_main_worktree_path, get_worktree_base
+from gwtlib.ui import prompt_yes_no
 
 
 def create_worktree_for_branch(branch_name, git_dir, worktree_path):
@@ -196,15 +194,6 @@ def _get_safe_dir_if_needed(worktree_path: str, git_dir: str) -> Optional[str]:
     return None
 
 
-def _is_worktree_dirty(worktree_path: str) -> bool:
-    """Check if worktree has uncommitted changes."""
-    try:
-        result = run_git_in_worktree(["status", "--porcelain"], worktree_path)
-        return bool(result.stdout.strip())
-    except subprocess.CalledProcessError:
-        return False
-
-
 def _is_worktree_locked(worktree_path: str, git_dir: str) -> bool:
     """Check if worktree is locked."""
     try:
@@ -246,7 +235,7 @@ def _preflight_check_removal(
     warnings = []
 
     # Check worktree state - dirty is a warning, locked is an error
-    if _is_worktree_dirty(worktree_path):
+    if is_worktree_dirty(worktree_path):
         warnings.append(f"Worktree has uncommitted changes: {worktree_path}")
 
     if _is_worktree_locked(worktree_path, git_dir):
@@ -499,7 +488,7 @@ def _remove_local_only(
     Order: local branch -> worktree (for best-effort atomicity).
     """
     # Check for dirty worktree upfront
-    if _is_worktree_dirty(worktree_path):
+    if is_worktree_dirty(worktree_path):
         print(
             f"WARNING: Worktree has uncommitted changes: {worktree_path}",
             file=sys.stderr,
@@ -563,7 +552,7 @@ def _remove_with_prompts(
     print("", file=sys.stderr)
 
     # Check for dirty worktree upfront
-    if _is_worktree_dirty(worktree_path):
+    if is_worktree_dirty(worktree_path):
         print(
             f"WARNING: Worktree has uncommitted changes: {worktree_path}",
             file=sys.stderr,

--- a/gwtlib/worktrees.py
+++ b/gwtlib/worktrees.py
@@ -195,7 +195,10 @@ def _get_safe_dir_if_needed(worktree_path: str, git_dir: str) -> Optional[str]:
 
 
 def _is_worktree_locked(worktree_path: str, git_dir: str) -> bool:
-    """Check if worktree is locked."""
+    """Check if worktree is locked.
+
+    Returns True (locked) if we cannot determine the state, to prevent accidental deletion.
+    """
     try:
         from gwtlib.parsing import parse_worktree_porcelain
 
@@ -204,8 +207,12 @@ def _is_worktree_locked(worktree_path: str, git_dir: str) -> bool:
             for entry in entries:
                 if entry.get("path") == worktree_path:
                     return entry.get("locked", False)
-    except Exception:
-        pass
+    except Exception as e:
+        print(
+            f"Warning: failed to check lock state for {worktree_path}: {e}",
+            file=sys.stderr,
+        )
+        return True  # Fail closed: assume locked if we can't check
     return False
 
 
@@ -293,6 +300,9 @@ def remove_worktree(branch_name: str, git_dir: str) -> None:
 
         # Determine branch state
         remote_ref = get_remote_tracking_branch(branch_name, git_dir)
+        # Fallback for branches pushed without upstream tracking
+        if remote_ref is None:
+            remote_ref = find_remote_branch(branch_name, git_dir)
         has_remote = remote_ref is not None and remote_branch_exists(
             remote_ref, git_dir
         )

--- a/justfile
+++ b/justfile
@@ -102,9 +102,9 @@ check-shell:
 
 # Install to ~/.local/bin (common on Linux/macOS)
 install-local: build
-  mkdir -p "$$HOME/.local/bin"
-  ln -sfn "$(pwd)/dist/gwt" "$$HOME/.local/bin/gwt"
-  @echo "Installed to $$HOME/.local/bin/gwt (symlink). Ensure $$HOME/.local/bin is in PATH."
+  mkdir -p "$HOME/.local/bin"
+  ln -sfn "$(pwd)/dist/gwt" "$HOME/.local/bin/gwt"
+  @echo "Installed to \$HOME/.local/bin/gwt (symlink). Ensure \$HOME/.local/bin is in PATH."
 
 # Clean artifacts
 clean:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,13 @@ def test_cli_remove_flow(tmp_path, git_env):
         assert res.returncode == 0
         # Verify worktree is actually removed
         assert not os.path.exists(wt_path), f"Worktree path {wt_path} should be removed"
+        # Verify local branch still exists (user declined deletion)
+        branch_check = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--verify", "refs/heads/feature"],
+            env=env_vars,
+            capture_output=True,
+        )
+        assert branch_check.returncode == 0, "Local branch 'feature' should still exist"
     finally:
         os.chdir(original_dir)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,7 @@ def test_cli_remove_flow(tmp_path, git_env):
             text=True,
         )
         assert res.returncode == 0
-        assert "removed" in res.stdout or "removed" in res.stderr
+        assert "removed" in res.stdout.lower() or "removed" in res.stderr.lower()
     finally:
         os.chdir(original_dir)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,8 @@ def test_cli_remove_flow(tmp_path, git_env):
             text=True,
         )
         assert res.returncode == 0
-        assert "removed" in res.stdout.lower() or "removed" in res.stderr.lower()
+        # Verify worktree is actually removed
+        assert not os.path.exists(wt_path), f"Worktree path {wt_path} should be removed"
     finally:
         os.chdir(original_dir)
 

--- a/tests/test_worktree_management.py
+++ b/tests/test_worktree_management.py
@@ -193,7 +193,7 @@ def test_list_worktrees_empty_when_none_exist(tmp_path, git_env):
         os.chdir(original_dir)
 
 
-def _init_bare_repo(bare_path: Path):
+def _init_bare_repo(bare_path: Path) -> None:
     """Initialize a bare repository."""
     subprocess.run(
         ["git", "init", "--bare", str(bare_path)],
@@ -203,7 +203,7 @@ def _init_bare_repo(bare_path: Path):
     )
 
 
-def _init_repo_with_remote(repo: Path, remote_path: Path):
+def _init_repo_with_remote(repo: Path, remote_path: Path) -> None:
     """Initialize a repo and add a local bare repo as 'origin'."""
     _init_repo(repo)
     subprocess.run(

--- a/tests/test_worktree_management.py
+++ b/tests/test_worktree_management.py
@@ -191,3 +191,128 @@ def test_list_worktrees_empty_when_none_exist(tmp_path, git_env):
         assert res.stdout.strip() == ""  # Empty output
     finally:
         os.chdir(original_dir)
+
+
+def _init_bare_repo(bare_path: Path):
+    """Initialize a bare repository."""
+    subprocess.run(
+        ["git", "init", "--bare", str(bare_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo_with_remote(repo: Path, remote_path: Path):
+    """Initialize a repo and add a local bare repo as 'origin'."""
+    _init_repo(repo)
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "add", "origin", str(remote_path)],
+        check=True,
+    )
+
+
+def _get_current_branch(repo: Path) -> str:
+    """Get the current branch name."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_get_remote_tracking_branch(tmp_path):
+    """Test get_remote_tracking_branch returns correct tracking ref."""
+    # Create a bare repo to act as "origin"
+    bare = tmp_path / "origin.git"
+    _init_bare_repo(bare)
+
+    # Create working repo with origin pointing to bare repo
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo_with_remote(repo, bare)
+    git_dir = str(repo / ".git")
+
+    # Get the default branch name (may be main or master)
+    default_branch = _get_current_branch(repo)
+
+    # Push default branch to origin to establish remote
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", default_branch],
+        check=True,
+        capture_output=True,
+    )
+
+    # Create and push a feature branch with tracking
+    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", "feature"],
+        check=True,
+        capture_output=True,
+    )
+
+    # Test: feature branch should track origin/feature
+    tracking = gwt.get_remote_tracking_branch("feature", git_dir)
+    assert tracking == "origin/feature"
+
+    # Test: non-tracking branch returns None
+    subprocess.run(["git", "-C", str(repo), "branch", "local-only"], check=True)
+    tracking = gwt.get_remote_tracking_branch("local-only", git_dir)
+    assert tracking is None
+
+    # Test: non-existent branch returns None
+    tracking = gwt.get_remote_tracking_branch("does-not-exist", git_dir)
+    assert tracking is None
+
+
+def test_remote_branch_exists(tmp_path):
+    """Test remote_branch_exists correctly detects remote branches."""
+    # Create a bare repo to act as "origin"
+    bare = tmp_path / "origin.git"
+    _init_bare_repo(bare)
+
+    # Create working repo with origin pointing to bare repo
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo_with_remote(repo, bare)
+    git_dir = str(repo / ".git")
+
+    # Get the default branch name (may be main or master)
+    default_branch = _get_current_branch(repo)
+
+    # Push default branch to origin
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", default_branch],
+        check=True,
+        capture_output=True,
+    )
+
+    # Fetch to ensure refs/remotes/origin/<default> exists locally
+    subprocess.run(
+        ["git", "-C", str(repo), "fetch", "origin"],
+        check=True,
+        capture_output=True,
+    )
+
+    # Test: origin/<default_branch> should exist
+    assert gwt.remote_branch_exists(f"origin/{default_branch}", git_dir) is True
+
+    # Test: origin/nonexistent should not exist
+    assert gwt.remote_branch_exists("origin/nonexistent", git_dir) is False
+
+    # Push a feature branch and verify it exists
+    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "origin", "feature"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "fetch", "origin"],
+        check=True,
+        capture_output=True,
+    )
+
+    assert gwt.remote_branch_exists("origin/feature", git_dir) is True

--- a/tests/test_worktree_management.py
+++ b/tests/test_worktree_management.py
@@ -193,10 +193,11 @@ def test_list_worktrees_empty_when_none_exist(tmp_path, git_env):
         os.chdir(original_dir)
 
 
-def _init_bare_repo(bare_path: Path) -> None:
+def _init_bare_repo(bare_path: Path, env: dict = None) -> None:
     """Initialize a bare repository."""
     subprocess.run(
         ["git", "init", "--bare", str(bare_path)],
+        env=env,
         check=True,
         capture_output=True,
         text=True,
@@ -228,7 +229,7 @@ def test_get_remote_tracking_branch(tmp_path, git_env):
     """Test get_remote_tracking_branch returns correct tracking ref."""
     # Create a bare repo to act as "origin"
     bare = tmp_path / "origin.git"
-    _init_bare_repo(bare)
+    _init_bare_repo(bare, git_env)
 
     # Create working repo with origin pointing to bare repo
     repo = tmp_path / "repo"
@@ -278,7 +279,7 @@ def test_remote_branch_exists(tmp_path, git_env):
     """Test remote_branch_exists correctly detects remote branches."""
     # Create a bare repo to act as "origin"
     bare = tmp_path / "origin.git"
-    _init_bare_repo(bare)
+    _init_bare_repo(bare, git_env)
 
     # Create working repo with origin pointing to bare repo
     repo = tmp_path / "repo"

--- a/tests/test_worktree_management.py
+++ b/tests/test_worktree_management.py
@@ -203,11 +203,12 @@ def _init_bare_repo(bare_path: Path) -> None:
     )
 
 
-def _init_repo_with_remote(repo: Path, remote_path: Path) -> None:
+def _init_repo_with_remote(repo: Path, remote_path: Path, env: dict) -> None:
     """Initialize a repo and add a local bare repo as 'origin'."""
-    _init_repo(repo)
+    _init_repo(repo, env)
     subprocess.run(
         ["git", "-C", str(repo), "remote", "add", "origin", str(remote_path)],
+        env=env,
         check=True,
     )
 
@@ -223,7 +224,7 @@ def _get_current_branch(repo: Path) -> str:
     return result.stdout.strip()
 
 
-def test_get_remote_tracking_branch(tmp_path):
+def test_get_remote_tracking_branch(tmp_path, git_env):
     """Test get_remote_tracking_branch returns correct tracking ref."""
     # Create a bare repo to act as "origin"
     bare = tmp_path / "origin.git"
@@ -232,7 +233,7 @@ def test_get_remote_tracking_branch(tmp_path):
     # Create working repo with origin pointing to bare repo
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo_with_remote(repo, bare)
+    _init_repo_with_remote(repo, bare, git_env)
     git_dir = str(repo / ".git")
 
     # Get the default branch name (may be main or master)
@@ -241,14 +242,18 @@ def test_get_remote_tracking_branch(tmp_path):
     # Push default branch to origin to establish remote
     subprocess.run(
         ["git", "-C", str(repo), "push", "-u", "origin", default_branch],
+        env=git_env,
         check=True,
         capture_output=True,
     )
 
     # Create and push a feature branch with tracking
-    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "feature"], env=git_env, check=True
+    )
     subprocess.run(
         ["git", "-C", str(repo), "push", "-u", "origin", "feature"],
+        env=git_env,
         check=True,
         capture_output=True,
     )
@@ -258,7 +263,9 @@ def test_get_remote_tracking_branch(tmp_path):
     assert tracking == "origin/feature"
 
     # Test: non-tracking branch returns None
-    subprocess.run(["git", "-C", str(repo), "branch", "local-only"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "local-only"], env=git_env, check=True
+    )
     tracking = gwt.get_remote_tracking_branch("local-only", git_dir)
     assert tracking is None
 
@@ -267,7 +274,7 @@ def test_get_remote_tracking_branch(tmp_path):
     assert tracking is None
 
 
-def test_remote_branch_exists(tmp_path):
+def test_remote_branch_exists(tmp_path, git_env):
     """Test remote_branch_exists correctly detects remote branches."""
     # Create a bare repo to act as "origin"
     bare = tmp_path / "origin.git"
@@ -276,7 +283,7 @@ def test_remote_branch_exists(tmp_path):
     # Create working repo with origin pointing to bare repo
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo_with_remote(repo, bare)
+    _init_repo_with_remote(repo, bare, git_env)
     git_dir = str(repo / ".git")
 
     # Get the default branch name (may be main or master)
@@ -285,6 +292,7 @@ def test_remote_branch_exists(tmp_path):
     # Push default branch to origin
     subprocess.run(
         ["git", "-C", str(repo), "push", "-u", "origin", default_branch],
+        env=git_env,
         check=True,
         capture_output=True,
     )
@@ -292,6 +300,7 @@ def test_remote_branch_exists(tmp_path):
     # Fetch to ensure refs/remotes/origin/<default> exists locally
     subprocess.run(
         ["git", "-C", str(repo), "fetch", "origin"],
+        env=git_env,
         check=True,
         capture_output=True,
     )


### PR DESCRIPTION
- Improve the `gwt rm` command to check for ability to remove before trying to remove.  Also reorder the operations.  This increases chances for (but doesn't guarantee) atomicity, reduces weird half-delete states.
- Add the ability for `gwt rm` to also delete / clean up the remote branch
- Add a `gwt gc` garbage collection subcommand.  This:
  - Checks all worktrees for latest modified files, to construct a "last used" timestamp
  - For worktrees older than *n* days, runs a *clean* command (e.g., `just clean` or `cargo clean`) to remove build artifacts
  - For worktrees older than *m* days, checks for deletability:
    - If git dir is dirty, mark for manual inspection
    - If git is clean, but branch has changes not yet merged to main, mark for manual inspection
    - Otherwise, add to a deletable list
  - Construct a plan showing the fate of each worktree
  - Depending on whether invoked with `--plan` or not, just show the plan, or show and execute the plan

Example plan output:
```
❯ gwt gc --plan
Scanning: 100%|███████████████| 46/46 [00:18<00:00,  2.43worktree/s]

Will clean 6 worktrees over 7 days old:
  allison-eng-264-corpsite-deployment  (75d) [dirty]
  allison-gen-10-rust-builds-are-unnecessarily-slow-across-worktrees-and-ci  (74d)
  example  (62d)
  eric-diagnose-build-2026-01  (26d)
  eric-eng-mk-pr-split-command  (13d)
  eric-eng-403-http-tests-for-clients  (13d)

Will delete 3 worktrees over 28 days old:
  eea-test-3  (188d)
  eric-gen-49-clean-up-cargo-machete-workaround-comment  (135d)
  eric-align-vscode-settings  (43d)

Old but dirty, inspect manually (1):
  allison-eng-264-corpsite-deployment  (75d)

Old but unmerged, inspect manually (2):
  allison-gen-10-rust-builds-are-unnecessarily-slow-across-worktrees-and-ci  (74d)
  example  (62d)
  eric-eng-320-get_product-silently-returns-ok-for-invalid-conceptrefs  (38d)

Keeping 20 recent worktree(s)
```
