### PR TITLE
Add Python 3.14 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 

--- a/gwtlib/cli.py
+++ b/gwtlib/cli.py
@@ -38,8 +38,6 @@ def main():
     )
     switch_parser.add_argument(
         "--guess",
-        "--no-guess",
-        dest="guess",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Guess remote branch names (default: enabled)",


### PR DESCRIPTION
## Summary

- Add Python 3.14 to the CI test matrix
- Fix Python 3.14 compatibility in `BooleanOptionalAction` usage

## Details

Python 3.14 changed `argparse.BooleanOptionalAction` to reject option names starting with `--no-` since it auto-generates the `--no-` variant automatically. This behavior has existed since `BooleanOptionalAction` was introduced in Python 3.9, so the explicit `--no-guess` was always redundant—it just wasn't an error until 3.14.

The fix removes the redundant `--no-guess` option string, letting `BooleanOptionalAction` derive it from `--guess` as intended.