### PR TITLE
Isolate git tests from user configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def git_env(tmp_path):
+    """Return environment dict isolating git from user config."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "HOME": str(home),
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test User",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    env.pop("GWT_GIT_DIR", None)  # Tests should set this explicitly
+    return env

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,18 +13,13 @@ def _run_cli(tmp_path, args, env=None, input_bytes=None):
     return subprocess.run(cmd, env=e, input=input_bytes, capture_output=True, text=True)
 
 
-def _init_repo(repo: Path):
+def _init_repo(repo: Path, env: dict):
     subprocess.run(
-        ["git", "init", str(repo)], check=True, capture_output=True, text=True
-    )
-    subprocess.run(
-        ["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True
-    )
-    subprocess.run(
-        ["git", "-C", str(repo), "config", "user.name", "Test User"], check=True
+        ["git", "init", str(repo)], env=env, check=True, capture_output=True, text=True
     )
     subprocess.run(
         ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+        env=env,
         check=True,
         capture_output=True,
         text=True,
@@ -41,12 +36,14 @@ def test_cli_repo_sets_env_line(tmp_path):
     assert "GWT_GIT_DIR=" in res.stdout
 
 
-def test_cli_list_branches_only_local(tmp_path):
+def test_cli_list_branches_only_local(tmp_path, git_env):
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
     # Create a branch
-    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "feature"], env=git_env, check=True
+    )
 
     # Run from outside any git repo to avoid auto-detection interference
     outside = tmp_path / "outside"
@@ -54,7 +51,7 @@ def test_cli_list_branches_only_local(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env_vars = os.environ.copy()
+    env_vars = git_env.copy()
     env_vars["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
     env_vars["GWT_GIT_DIR"] = str(repo / ".git")
 
@@ -76,24 +73,26 @@ def test_cli_list_branches_only_local(tmp_path):
         os.chdir(original_dir)
 
 
-def test_cli_switch_no_guess_missing_branch(tmp_path):
+def test_cli_switch_no_guess_missing_branch(tmp_path, git_env):
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
-    env = {"GWT_GIT_DIR": str(repo / ".git")}
+    _init_repo(repo, git_env)
+    env = {**git_env, "GWT_GIT_DIR": str(repo / ".git")}
     # No such branch, and --no-guess
     res = _run_cli(tmp_path, ["switch", "--no-guess", "does-not-exist"], env=env)
     assert res.returncode != 0
     assert "invalid reference" in res.stderr
 
 
-def test_cli_remove_flow(tmp_path):
+def test_cli_remove_flow(tmp_path, git_env):
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
-    env = {"GWT_GIT_DIR": str(repo / ".git")}
+    _init_repo(repo, git_env)
+    env = {**git_env, "GWT_GIT_DIR": str(repo / ".git")}
     # Create branch & worktree using the CLI path
-    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "feature"], env=git_env, check=True
+    )
     # Use the module function to add the worktree to keep this faster
     import gwt as g
 
@@ -107,7 +106,7 @@ def test_cli_remove_flow(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env_vars = os.environ.copy()
+    env_vars = git_env.copy()
     env_vars["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
     env_vars["GWT_GIT_DIR"] = str(repo / ".git")
 
@@ -128,14 +127,14 @@ def test_cli_remove_flow(tmp_path):
         os.chdir(original_dir)
 
 
-def test_auto_detect_from_repo_root(tmp_path):
+def test_auto_detect_from_repo_root(tmp_path, git_env):
     """Test auto-detection when run from repo root."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
 
     # No env or config set
-    env = {"XDG_CONFIG_HOME": str(tmp_path / "xdg")}
+    env = {**git_env, "XDG_CONFIG_HOME": str(tmp_path / "xdg")}
 
     # Get absolute path to gwt.py (in repo root, parent of tests directory)
     gwt_script = Path(__file__).parent.parent / "gwt.py"
@@ -155,15 +154,15 @@ def test_auto_detect_from_repo_root(tmp_path):
         os.chdir(original_dir)
 
 
-def test_auto_detect_from_subdirectory(tmp_path):
+def test_auto_detect_from_subdirectory(tmp_path, git_env):
     """Test auto-detection when run from subdirectory."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
     subdir = repo / "src" / "components"
     subdir.mkdir(parents=True)
 
-    env = {"XDG_CONFIG_HOME": str(tmp_path / "xdg")}
+    env = {**git_env, "XDG_CONFIG_HOME": str(tmp_path / "xdg")}
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
@@ -182,18 +181,19 @@ def test_auto_detect_from_subdirectory(tmp_path):
         os.chdir(original_dir)
 
 
-def test_auto_detect_priority_over_env(tmp_path):
+def test_auto_detect_priority_over_env(tmp_path, git_env):
     """Test that auto-detect takes priority over GWT_GIT_DIR."""
     repo_a = tmp_path / "repo_a"
     repo_a.mkdir()
-    _init_repo(repo_a)
+    _init_repo(repo_a, git_env)
 
     repo_b = tmp_path / "repo_b"
     repo_b.mkdir()
-    _init_repo(repo_b)
+    _init_repo(repo_b, git_env)
 
     # Set env to repo B, but run from repo A
     env = {
+        **git_env,
         "XDG_CONFIG_HOME": str(tmp_path / "xdg"),
         "GWT_GIT_DIR": str(repo_b / ".git"),
     }
@@ -217,16 +217,20 @@ def test_auto_detect_priority_over_env(tmp_path):
         os.chdir(original_dir)
 
 
-def test_fallback_to_env_outside_repo(tmp_path):
+def test_fallback_to_env_outside_repo(tmp_path, git_env):
     """Test fallback to env when outside any repo."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
 
     outside = tmp_path / "outside"
     outside.mkdir()
 
-    env = {"XDG_CONFIG_HOME": str(tmp_path / "xdg"), "GWT_GIT_DIR": str(repo / ".git")}
+    env = {
+        **git_env,
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg"),
+        "GWT_GIT_DIR": str(repo / ".git"),
+    }
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
@@ -245,12 +249,16 @@ def test_fallback_to_env_outside_repo(tmp_path):
         os.chdir(original_dir)
 
 
-def test_error_when_env_invalid(tmp_path):
+def test_error_when_env_invalid(tmp_path, git_env):
     """Test E002 error when GWT_GIT_DIR points to invalid path."""
     outside = tmp_path / "outside"
     outside.mkdir()
 
-    env = {"XDG_CONFIG_HOME": str(tmp_path / "xdg"), "GWT_GIT_DIR": "/nonexistent/path"}
+    env = {
+        **git_env,
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg"),
+        "GWT_GIT_DIR": "/nonexistent/path",
+    }
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
@@ -271,12 +279,12 @@ def test_error_when_env_invalid(tmp_path):
         os.chdir(original_dir)
 
 
-def test_error_when_no_repo_found(tmp_path):
+def test_error_when_no_repo_found(tmp_path, git_env):
     """Test E001 error when no repo detected and no config."""
     outside = tmp_path / "outside"
     outside.mkdir()
 
-    env = {"XDG_CONFIG_HOME": str(tmp_path / "xdg")}
+    env = {**git_env, "XDG_CONFIG_HOME": str(tmp_path / "xdg")}
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
@@ -297,14 +305,16 @@ def test_error_when_no_repo_found(tmp_path):
         os.chdir(original_dir)
 
 
-def test_list_annotate_fish_format(tmp_path):
+def test_list_annotate_fish_format(tmp_path, git_env):
     """Test that list --annotate fish outputs tab-separated descriptions."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
 
     # Create branches
-    subprocess.run(["git", "-C", str(repo), "branch", "local-only"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "local-only"], env=git_env, check=True
+    )
 
     # Run from outside any git repo to avoid auto-detection interference
     outside = tmp_path / "outside"
@@ -312,7 +322,7 @@ def test_list_annotate_fish_format(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env_vars = os.environ.copy()
+    env_vars = git_env.copy()
     env_vars["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
     env_vars["GWT_GIT_DIR"] = str(repo / ".git")
 
@@ -348,14 +358,16 @@ def test_list_annotate_fish_format(tmp_path):
         os.chdir(original_dir)
 
 
-def test_list_annotate_bash_format(tmp_path):
+def test_list_annotate_bash_format(tmp_path, git_env):
     """Test that list --annotate bash outputs symbol-prefixed branches."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
 
     # Create branches
-    subprocess.run(["git", "-C", str(repo), "branch", "local-only"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "local-only"], env=git_env, check=True
+    )
 
     # Run from outside any git repo to avoid auto-detection interference
     outside = tmp_path / "outside"
@@ -363,7 +375,7 @@ def test_list_annotate_bash_format(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env_vars = os.environ.copy()
+    env_vars = git_env.copy()
     env_vars["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
     env_vars["GWT_GIT_DIR"] = str(repo / ".git")
 
@@ -395,11 +407,11 @@ def test_list_annotate_bash_format(tmp_path):
         os.chdir(original_dir)
 
 
-def test_list_annotate_none_is_plain(tmp_path):
+def test_list_annotate_none_is_plain(tmp_path, git_env):
     """Test that list without --annotate outputs plain branch names."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
 
     # Run from outside any git repo to avoid auto-detection interference
     outside = tmp_path / "outside"
@@ -407,7 +419,7 @@ def test_list_annotate_none_is_plain(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env_vars = os.environ.copy()
+    env_vars = git_env.copy()
     env_vars["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
     env_vars["GWT_GIT_DIR"] = str(repo / ".git")
 

--- a/tests/test_worktree_management.py
+++ b/tests/test_worktree_management.py
@@ -73,34 +73,30 @@ def test_parse_worktree_legacy(monkeypatch, tmp_path):
     assert entries[2]["detached"]
 
 
-def _init_repo(repo: Path):
+def _init_repo(repo: Path, env: dict):
     subprocess.run(
-        ["git", "init", str(repo)], check=True, capture_output=True, text=True
-    )
-    # Configure identity for commits
-    subprocess.run(
-        ["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True
-    )
-    subprocess.run(
-        ["git", "-C", str(repo), "config", "user.name", "Test User"], check=True
+        ["git", "init", str(repo)], env=env, check=True, capture_output=True, text=True
     )
     # Initial empty commit
     subprocess.run(
         ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+        env=env,
         check=True,
         capture_output=True,
         text=True,
     )
 
 
-def test_branch_exists_locally_and_worktree_listing(tmp_path):
+def test_branch_exists_locally_and_worktree_listing(tmp_path, git_env):
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
     git_dir = str(repo / ".git")
 
     # Create a new branch
-    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "feature"], env=git_env, check=True
+    )
 
     assert gwt.branch_exists_locally("feature", git_dir)
     assert not gwt.branch_exists_locally("nope", git_dir)
@@ -116,17 +112,19 @@ def test_branch_exists_locally_and_worktree_listing(tmp_path):
     assert "feature" in branches
 
 
-def test_list_worktrees_excludes_main(tmp_path):
+def test_list_worktrees_excludes_main(tmp_path, git_env):
     """Test that list --branches worktrees excludes main branch."""
     import sys
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
     git_dir = str(repo / ".git")
 
     # Create a worktree branch
-    subprocess.run(["git", "-C", str(repo), "branch", "feature"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "feature"], env=git_env, check=True
+    )
 
     wt_base = gwt.get_worktree_base(git_dir)
     wt_path = os.path.join(wt_base, "feature")
@@ -138,7 +136,7 @@ def test_list_worktrees_excludes_main(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env = os.environ.copy()
+    env = git_env.copy()
     env["GWT_GIT_DIR"] = git_dir
     env["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
 
@@ -160,13 +158,13 @@ def test_list_worktrees_excludes_main(tmp_path):
         os.chdir(original_dir)
 
 
-def test_list_worktrees_empty_when_none_exist(tmp_path):
+def test_list_worktrees_empty_when_none_exist(tmp_path, git_env):
     """Test that list --branches worktrees returns empty when no worktrees."""
     import sys
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_repo(repo)
+    _init_repo(repo, git_env)
     git_dir = str(repo / ".git")
 
     # Run from outside any git repo to avoid auto-detection interference
@@ -175,7 +173,7 @@ def test_list_worktrees_empty_when_none_exist(tmp_path):
 
     # Get absolute path to gwt.py
     gwt_script = Path(__file__).parent.parent / "gwt.py"
-    env = os.environ.copy()
+    env = git_env.copy()
     env["GWT_GIT_DIR"] = git_dir
     env["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
 


### PR DESCRIPTION
## Summary

- Add `git_env` pytest fixture to isolate tests from user's git configuration
- Update all tests that invoke git to use the isolated environment

## Problem

Tests were inheriting the user's git configuration, which caused:
- 1Password approval dialogs popping up for GPG commit signing
- Potential test failures or inconsistent behavior based on user's git aliases, settings, etc.

## Solution

The `git_env` fixture provides an isolated environment dict that:
- Blocks `~/.gitconfig` via `GIT_CONFIG_GLOBAL=/dev/null`
- Blocks `/etc/gitconfig` via `GIT_CONFIG_SYSTEM=/dev/null`
- Sets `HOME` to a temp directory as fallback isolation
- Provides git identity via `GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables
- Removes `GWT_GIT_DIR` so tests must set it explicitly

Tests explicitly pass this environment to all git subprocess calls rather than using an autouse fixture that monkeypatches `os.environ`.

## Alternatives

I'm not specifically attached to this approach. Other options considered:
- **Autouse fixture with monkeypatch**: Simpler (no changes to test functions) but hides the environment mutation
- **Override HOME only**: Simpler but less complete isolation
- **Local repo config**: Run `git config --local` in each test repo, but doesn't block all global settings

Open to feedback on the approach.